### PR TITLE
Agrego blacklist de metadatos

### DIFF
--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -6,6 +6,7 @@ from os.path import dirname
 import environ
 
 from .api import *
+from .metadata import *
 
 SETTINGS_DIR = environ.Path(__file__) - 1
 ROOT_DIR = environ.Path(__file__) - 3  # (/a/b/myfile.py - 3 = /)

--- a/conf/settings/metadata.py
+++ b/conf/settings/metadata.py
@@ -1,0 +1,19 @@
+#! coding: utf-8
+
+CATALOG_BLACKLIST = [
+    "themeTaxonomy"
+]
+
+DATASET_BLACKLIST = [
+
+]
+
+DISTRIBUTION_BLACKLIST = [
+    "scrapingFileSheet"
+]
+
+FIELD_BLACKLIST = [
+    "scrapingDataStartCell",
+    "scrapingIdentifierCell",
+    "scrapingDataStartCell",
+]

--- a/series_tiempo_ar_api/apps/api/tests/samples/full_ts_data.json
+++ b/series_tiempo_ar_api/apps/api/tests/samples/full_ts_data.json
@@ -107,7 +107,8 @@
                             "units": "Millones de pesos",
                             "id": "212.1_PSCIOS_ERS_0_0_22",
                             "description": "PIB Servicios Comunales, Sociales y Personales en millones de pesos de 1960. Total",
-                            "title": "pib_scios_com_soc_pers"
+                            "title": "pib_scios_com_soc_pers",
+                            "scrapingIdentifierCell": "AC9"
                         },
                         {
                             "units": "Millones de pesos",
@@ -119,12 +120,14 @@
                             "units": "Millones de pesos",
                             "id": "212.1_PSCIOS_IOS_0_0_25",
                             "description": "PIB Servicios Comunales, Sociales y Personales en millones de pesos de 1960. Otros Servicios",
-                            "title": "pib_scios_com_otros_scios"
+                            "title": "pib_scios_com_otros_scios",
+                            "scrapingDataStartCell": "AD10"
                         }
                     ],
                     "draft": false,
                     "units": "Millones de pesos",
-                    "identifier": "212.1"
+                    "identifier": "212.1",
+                    "scrapingFileSheet": "32. Ingreso IED Pais"
                 }
             ]
         }


### PR DESCRIPTION
Indican al DatabaseLoader que metadatos del data.json descartar al momento
de guardarlos en la base de datos durante el proceso de indexación.

Quedaría pendiente llenar estas listas negras con los campos a ignorar.