### PR TITLE
Agrega opción de metadatos simples

### DIFF
--- a/conf/settings/api.py
+++ b/conf/settings/api.py
@@ -66,7 +66,7 @@ API_DEFAULT_VALUES = {
     'collapse': 'year',
     'start': 0,
     'limit': 100,
-    'metadata': 'full',
+    'metadata': 'simple',
     'sort': 'asc'
 }
 
@@ -95,4 +95,30 @@ METADATA_SETTINGS = [
 SORT_VALUES = [
     'asc',
     'desc'
+]
+
+CATALOG_SIMPLE_META_FIELDS = [
+    'title',
+    'dataset'
+]
+
+DATASET_SIMPLE_META_FIELDS = [
+    'distribution',
+    'title',
+    'description',
+    'issued',
+    'source'
+]
+
+DISTRIBUTION_SIMPLE_META_FIELDS = [
+    'field',
+    'title',
+    'downloadURL',
+    'units',
+]
+
+FIELD_SIMPLE_META_FIELDS = [
+    'id',
+    'description',
+    'units'
 ]


### PR DESCRIPTION
Closes #27 

`metadata=simple` (opción por defecto) devuelve una lista reducida de metadatos. Los metadatos considerados como simples es configurable desde el módulo `api.py` en `settings`.