### PR TITLE
67 collapse fix

### DIFF
--- a/series_tiempo_ar_api/apps/api/common/__init__.py
+++ b/series_tiempo_ar_api/apps/api/common/__init__.py
@@ -1,0 +1,1 @@
+#! coding: utf-8

--- a/series_tiempo_ar_api/apps/api/common/constants.py
+++ b/series_tiempo_ar_api/apps/api/common/constants.py
@@ -1,0 +1,7 @@
+
+# Transformaciones
+VALUE = 'value'
+CHANGE = 'change'
+PCT_CHANGE = 'percent_change'
+CHANGE_YEAR_AGO = 'change_a_year_ago'
+PCT_CHANGE_YEAR_AGO = 'percent_change_a_year_ago'

--- a/series_tiempo_ar_api/apps/api/common/operations.py
+++ b/series_tiempo_ar_api/apps/api/common/operations.py
@@ -1,0 +1,76 @@
+#! coding: utf-8
+
+"""Operaciones de cálculos de variaciones absolutas y porcentuales anuales"""
+
+import pandas as pd
+import numpy as np
+from dateutil.relativedelta import relativedelta
+
+from series_tiempo_ar_api.apps.api.helpers import freq_pandas_to_index_offset
+
+
+def get_value(df, col, index):
+    """Devuelve el valor del df[col][index] o 0 si no es válido.
+    Evita Cargar Infinity y NaN en Elasticsearch
+    """
+    series = df[col]
+    if index not in series:
+        return 0
+
+    value = series[index]
+    return value if np.isfinite(value) else 0
+
+
+def year_ago_column(col, freq, operation):
+    """Aplica operación entre los datos de una columna y su valor
+    un año antes. Devuelve una nueva serie de pandas.
+    """
+    array = []
+    offset = freq_pandas_to_index_offset(freq) or 0
+    if offset:
+        values = col.values
+        array = operation(values[offset:], values[:-offset])
+    else:
+        for idx, val in col.iteritems():
+            value = get_value_a_year_ago(idx, col, validate=True)
+            if value != 0:
+                array.append(operation(val, value))
+            else:
+                array.append(None)
+
+    return pd.Series(array, index=col.index[offset:])
+
+
+def get_value_a_year_ago(idx, col, validate=False):
+    """Devuelve el valor de la serie determinada por df[col] un
+    año antes del índice de tiempo 'idx'. Hace validación de si
+    existe el índice o no según 'validate' (operación costosa)
+    """
+
+    value = 0
+    year_ago_idx = idx.date() - relativedelta(years=1)
+    if not validate:
+        if year_ago_idx not in col.index:
+            return 0
+
+        value = col[year_ago_idx]
+    else:
+        if year_ago_idx in col:
+            value = col[year_ago_idx]
+
+    return value
+
+
+def change_a_year_ago(col, freq):
+    def change(x, y):
+        return x - y
+    return year_ago_column(col, freq, change)
+
+
+def pct_change_a_year_ago(col, freq):
+    def _pct_change(x, y):
+        if isinstance(y, int) and y == 0:
+            return 0
+        return (x - y) / y
+
+    return year_ago_column(col, freq, _pct_change)

--- a/series_tiempo_ar_api/apps/api/indexing/constants.py
+++ b/series_tiempo_ar_api/apps/api/indexing/constants.py
@@ -1,5 +1,6 @@
 #! coding: utf-8
 from django.conf import settings
+from ..common.constants import *
 
 IDENTIFIER = "identifier"
 DATASET_IDENTIFIER = "dataset_identifier"
@@ -13,13 +14,6 @@ FIELD_ID = 'id'
 SPECIAL_TYPE = 'specialType'
 SPECIAL_TYPE_DETAIL = 'specialTypeDetail'
 TIME_INDEX = 'time_index'
-
-# Transformaciones a indexar
-VALUE = 'value'
-CHANGE = 'change'
-PCT_CHANGE = 'percent_change'
-CHANGE_YEAR_AGO = 'change_a_year_ago'
-PCT_CHANGE_YEAR_AGO = 'percent_change_a_year_ago'
 
 # JSON del mapping de series de tiempo
 MAPPING = {

--- a/series_tiempo_ar_api/apps/api/indexing/constants.py
+++ b/series_tiempo_ar_api/apps/api/indexing/constants.py
@@ -1,6 +1,6 @@
 #! coding: utf-8
 from django.conf import settings
-from ..common.constants import *
+from ..common.constants import VALUE, CHANGE, PCT_CHANGE, CHANGE_YEAR_AGO, PCT_CHANGE_YEAR_AGO
 
 IDENTIFIER = "identifier"
 DATASET_IDENTIFIER = "dataset_identifier"

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -1,6 +1,6 @@
 #! coding: utf-8
 
-from ..common.constants import *
+from ..common.constants import VALUE, CHANGE, PCT_CHANGE, CHANGE_YEAR_AGO, PCT_CHANGE_YEAR_AGO
 # Modos de representación de las series, calculados y guardados
 # en el proceso de indexación
 REP_MODES = [

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -1,13 +1,14 @@
 #! coding: utf-8
 
+from ..common.constants import *
 # Modos de representación de las series, calculados y guardados
 # en el proceso de indexación
 REP_MODES = [
-    'value',
-    'change',
-    'change_a_year_ago',
-    'percent_change',
-    'percent_change_a_year_ago'
+    VALUE,
+    CHANGE,
+    PCT_CHANGE,
+    CHANGE_YEAR_AGO,
+    PCT_CHANGE_YEAR_AGO
 ]
 
 AGGREGATIONS = [

--- a/series_tiempo_ar_api/apps/api/query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query.py
@@ -267,15 +267,15 @@ class CollapseQuery(ESQuery):
         df, freq = self._init_df()
 
         for i, serie in enumerate(self.series, 1):
-            if serie.rep_mode == 'value':
+            if serie.rep_mode == constants.VALUE:
                 pass
-            elif serie.rep_mode == 'change':
+            elif serie.rep_mode == constants.CHANGE:
                 df[i] = df[i].diff(1)
-            elif serie.rep_mode == 'percent_change':
+            elif serie.rep_mode == constants.PCT_CHANGE:
                 df[i] = df[i].pct_change(1, fill_method=None)
-            elif serie.rep_mode == 'change_a_year_ago':
+            elif serie.rep_mode == constants.CHANGE_YEAR_AGO:
                 df[i] = change_a_year_ago(df[i], freq)
-            elif serie.rep_mode == 'percent_change_a_year_ago':
+            elif serie.rep_mode == constants.PCT_CHANGE_YEAR_AGO:
                 df[i] = pct_change_a_year_ago(df[i], freq)
 
         df = df.where((pd.notnull(df)), None)  # Reemplaza valores nulos (NaN) por None de python


### PR DESCRIPTION
- Extrae las funciones de cálculos de las transformaciones de los datos (`change`, `percent_change`, ...) usados en la indexación a un módulo `common`
- Usa esas funciones para aplicar las transformaciones *despúes* de traer los datos cuando se hace una llamada a la API que pida datos con el intervalo de tiempo colapsado.