### PR TITLE
Valido y uso el parámetro collapse_aggregation por separado de collapse

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/pipeline.py
+++ b/series_tiempo_ar_api/apps/api/query/pipeline.py
@@ -63,6 +63,7 @@ class QueryPipeline(object):
             Pagination,
             Sort,
             Collapse,
+            CollapseAggregation,
             Metadata,
             Format
         ]
@@ -308,18 +309,25 @@ class Collapse(BaseOperation):
             self._append_error(msg)
             return
 
-        agg = args.get(constants.PARAM_COLLAPSE_AGG,
-                       constants.API_DEFAULT_VALUES[constants.PARAM_COLLAPSE_AGG])
+        try:
+            query.add_collapse(collapse=collapse)
+        except CollapseError:
+            msg = strings.INVALID_COLLAPSE.format(collapse)
+            self._append_error(msg)
 
-        if agg not in constants.AGGREGATIONS:
+
+class CollapseAggregation(BaseOperation):
+    def run(self, query, args):
+        agg = args.get(constants.PARAM_COLLAPSE_AGG)
+
+        if agg and agg not in constants.AGGREGATIONS:
             msg = strings.INVALID_PARAMETER.format(constants.PARAM_COLLAPSE_AGG, agg)
             self._append_error(msg)
-        else:
-            try:
-                query.add_collapse(agg, collapse)
-            except CollapseError:
-                msg = strings.INVALID_COLLAPSE.format(collapse)
-                self._append_error(msg)
+
+        try:
+            query.set_collapse_aggregation(agg)
+        except CollapseError:
+            pass  # Se especifica un collapse aggregation sin collapse, lo ignoro
 
 
 class Metadata(BaseOperation):

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -77,6 +77,11 @@ class Query(object):
         self.es_query = CollapseQuery(self.es_query)
         self.es_query.add_collapse(agg, collapse)
 
+    def set_collapse_aggregation(self, agg):
+        if not hasattr(self.es_query, 'collapse_aggregation'):
+            raise CollapseError
+        self.es_query.add_collapse(agg=agg)
+
     def set_metadata_config(self, how):
         self.metadata_config = how
 

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests.py
@@ -4,7 +4,7 @@ from iso8601 import iso8601
 
 from series_tiempo_ar_api.apps.api.models import Field
 from series_tiempo_ar_api.apps.api.query.pipeline import \
-    NameAndRepMode, Collapse, Pagination, DateFilter, Sort
+    NameAndRepMode, Collapse, Pagination, DateFilter, Sort, CollapseAggregation
 from series_tiempo_ar_api.apps.api.query.query import Query
 from series_tiempo_ar_api.apps.api.query.strings import SERIES_DOES_NOT_EXIST
 from .helpers import setup_database
@@ -113,10 +113,15 @@ class CollapseTest(TestCase):
                                   'collapse_aggregation': 'sum'})
         self.assertFalse(self.cmd.errors)
 
+
+class CollapseAggregationTests(TestCase):
+
+    def setUp(self):
+        self.query = Query()
+        self.cmd = CollapseAggregation()
+
     def test_invalid_aggregation(self):
-        self.cmd.run(self.query, {'ids': self.single_series,
-                                  'collapse': 'year',
-                                  'collapse_aggregation': 'INVALID'})
+        self.cmd.run(self.query, {'collapse_aggregation': 'INVALID'})
         self.assertTrue(self.cmd.errors)
 
 


### PR DESCRIPTION
Closes #65 

Anteriormente se validaba el parámetro collapse_aggregation sólo si existía un collapse, ahora se hace de manera independiente. Esto corrige situaciones de colapso automático cuando se piden múltiples series de tiempo.