### PR TITLE
60 week collapse

### DIFF
--- a/series_tiempo_ar_api/apps/api/helpers.py
+++ b/series_tiempo_ar_api/apps/api/helpers.py
@@ -48,6 +48,7 @@ def get_relative_delta(periodicity):
 
     deltas = {
         'day': relativedelta(days=1),
+        'week': relativedelta(days=7),
         'month': relativedelta(months=1),
         'quarter': relativedelta(months=3),
         'year': relativedelta(years=1)

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -20,6 +20,7 @@ AGGREGATIONS = [
 
 COLLAPSE_INTERVALS = [  # EN ORDEN DE MENOR A MAYOR
     'day',
+    'week',
     'month',
     'quarter',
     'semester',

--- a/series_tiempo_ar_api/apps/api/query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query.py
@@ -283,6 +283,11 @@ class CollapseQuery(ESQuery):
         for row in self.data:
             row[0] = str(row[0].date())  # conversión de pandas Timestamp a date de Python
 
+            # Fix a issue #63 de precisión de floats
+            # https://github.com/datosgobar/series-tiempo-ar-api/issues/63
+            for i, data in enumerate(row[1:], 1):
+                row[i] = round(data, 12) if data is not None else data
+
         if self.args[constants.PARAM_SORT] == constants.SORT_DESCENDING:
             self.data.reverse()
 

--- a/series_tiempo_ar_api/apps/api/query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query.py
@@ -294,6 +294,7 @@ class CollapseQuery(ESQuery):
         # Armado del índice de tiempo necesario para calcular transformaciones anuales
         translation = {
             'day': 'D',
+            'week': 'W-MON',
             'month': 'MS',
             'quarter': 'QS',
             'year': 'AS'

--- a/series_tiempo_ar_api/apps/api/tests/helpers.py
+++ b/series_tiempo_ar_api/apps/api/tests/helpers.py
@@ -24,3 +24,19 @@ def setup_database():
         distribution=distrib,
         title='random_month_0_title'
     )
+
+    init_daily_series(dataset)
+
+
+def init_daily_series(dataset):
+    distrib = Distribution.objects.create(identifier='132.2',
+                                          metadata='{}',
+                                          download_url="invalid_url",
+                                          dataset=dataset,
+                                          periodicity='R/P1D')
+    Field.objects.create(
+        series_id='random_series-day-0',
+        metadata='{}',
+        distribution=distrib,
+        title='random_day_0_title'
+    )

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -1,4 +1,5 @@
 #! coding: utf-8
+import iso8601
 from django.conf import settings
 from django.test import TestCase
 from nose.tools import raises
@@ -70,3 +71,18 @@ class QueryTests(TestCase):
         self.assertEqual(ids['id'], field.series_id)
         self.assertEqual(ids['distribution'], field.distribution.identifier)
         self.assertEqual(ids['dataset'], field.distribution.dataset.identifier)
+
+    def test_weekly_collapse(self):
+        field = Field.objects.get(series_id='random_series-day-0')
+
+        self.query.add_series('random_series-day-0', field)
+
+        self.query.add_collapse(collapse='week')
+
+        data = self.query.run()['data']
+
+        first_date = iso8601.parse_date(data[0][0])
+        second_date = iso8601.parse_date(data[1][0])
+
+        delta = second_date - first_date
+        self.assertEqual(delta.days, 7)


### PR DESCRIPTION
- Permite pasar `collapse=week` a la API para obtener agregaciones semanales de las series
- Pequeño fix relacionado con #63 cuando se calculan los valores en el collapse de varias series