### PR TITLE
86 ignore case

### DIFF
--- a/series_tiempo_ar_api/apps/api/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/view_tests.py
@@ -5,11 +5,18 @@ from django.http import JsonResponse
 from django.test import TestCase, Client
 from django.urls import reverse
 
+from series_tiempo_ar_api.apps.api.tests.helpers import setup_database
+
 
 class ViewTests(TestCase):
 
     client = Client()
     endpoint = reverse('api:series')
+
+    @classmethod
+    def setUpClass(cls):
+        setup_database()
+        super(ViewTests, cls).setUpClass()
 
     def test_series_default_type(self):
         response = self.client.get(self.endpoint, data={'ids': 'random_series-month-0'})
@@ -20,10 +27,55 @@ class ViewTests(TestCase):
 
         self.assertTrue(response['errors'])
 
-    def test_args_ignore_case(self):
+    def test_csv_ignore_case(self):
         response = self.client.get(self.endpoint,
                                    data={'ids': 'random_series-month-0', 'format': 'csv'})
         response_upper = self.client.get(self.endpoint,
                                          data={'ids': 'random_series-month-0', 'format': 'CSV'})
 
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, response_upper.content)
+
+    def test_collapse_agg_ignore_case(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': 'random_series-month-0',
+                                         'collapse_aggregation': 'sum'})
+        response_upper = self.client.get(self.endpoint,
+                                         data={'ids': 'random_series-month-0',
+                                               'collapse_aggregation': 'SUM'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, response_upper.content)
+
+    def test_rep_mode_ignore_case(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': 'random_series-month-0',
+                                         'representation_mode': 'percent_change'})
+        response_upper = self.client.get(self.endpoint,
+                                         data={'ids': 'random_series-month-0',
+                                               'representation_mode': 'PERCENT_change'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, response_upper.content)
+
+    def test_sort_ignore_case(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': 'random_series-month-0',
+                                         'sort': 'desc'})
+        response_upper = self.client.get(self.endpoint,
+                                         data={'ids': 'random_series-month-0',
+                                               'sort': 'DESC'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, response_upper.content)
+
+    def test_metadata_ignore_case(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': 'random_series-month-0',
+                                         'metadata': 'none'})
+        response_upper = self.client.get(self.endpoint,
+                                         data={'ids': 'random_series-month-0',
+                                               'metadata': 'None'})
+
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, response_upper.content)

--- a/series_tiempo_ar_api/apps/api/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/view_tests.py
@@ -1,0 +1,29 @@
+#! coding: utf-8
+import json
+
+from django.http import JsonResponse
+from django.test import TestCase, Client
+from django.urls import reverse
+
+
+class ViewTests(TestCase):
+
+    client = Client()
+    endpoint = reverse('api:series')
+
+    def test_series_default_type(self):
+        response = self.client.get(self.endpoint, data={'ids': 'random_series-month-0'})
+        self.assertTrue(type(response) == JsonResponse)
+
+    def test_series_empty_args(self):
+        response = json.loads(self.client.get(self.endpoint).content)
+
+        self.assertTrue(response['errors'])
+
+    def test_args_ignore_case(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': 'random_series-month-0', 'format': 'csv'})
+        response_upper = self.client.get(self.endpoint,
+                                         data={'ids': 'random_series-month-0', 'format': 'CSV'})
+
+        self.assertEqual(response.content, response_upper.content)

--- a/series_tiempo_ar_api/apps/api/urls.py
+++ b/series_tiempo_ar_api/apps/api/urls.py
@@ -4,5 +4,5 @@ from django.conf.urls import url
 from series_tiempo_ar_api.apps.api.views import query_view
 
 urlpatterns = [
-    url('^series/$', query_view)
+    url('^series/$', query_view, name='series')
 ]

--- a/series_tiempo_ar_api/apps/api/views.py
+++ b/series_tiempo_ar_api/apps/api/views.py
@@ -1,8 +1,13 @@
 #! coding: utf-8
-
+from series_tiempo_ar_api.apps.api.query import constants
 from series_tiempo_ar_api.apps.api.query.pipeline import QueryPipeline
 
 
 def query_view(request):
     query = QueryPipeline()
-    return query.run(request.GET.copy())
+    # Formateo argumentos a lowercase, excepto ids
+    ids = request.GET.get(constants.PARAM_IDS)
+    args = {key: value.lower() for key, value in request.GET.items()}
+    args[constants.PARAM_IDS] = ids
+
+    return query.run(args)


### PR DESCRIPTION
Closes #86 

Al llegar un request, se itera sobre los parámetros del mismo y se llevan todos los valores a lowercase, 
*excepto* el de `ids`. Así la API se comporta de manera igual, independiente del *case* de cada parámetro.