### PR TITLE
Agrego un límite para la cantidad de series a pedir posibles

### DIFF
--- a/conf/settings/api.py
+++ b/conf/settings/api.py
@@ -28,5 +28,6 @@ VALID_STATUS_CODES = (
 
 MAX_ALLOWED_VALUES = {
     'start': 100000,  # tbd
-    'limit': 1000
+    'limit': 1000,
+    'ids': 20  # Cantidad máxima de series que se pueden pedir
 }

--- a/series_tiempo_ar_api/apps/api/query/pipeline.py
+++ b/series_tiempo_ar_api/apps/api/query/pipeline.py
@@ -227,6 +227,11 @@ class IdsField(BaseOperation):
 
         delim = ids.find(',')
         series = ids.split(',') if delim > -1 else [ids]
+        limit = settings.MAX_ALLOWED_VALUES[constants.PARAM_IDS]
+        if len(series) > limit:
+            self._append_error(strings.SERIES_OVER_LIMIT.format(limit))
+            return
+
         for serie_string in series:
             self.process_serie_string(query, serie_string, rep_mode, collapse_agg)
             if self.errors:

--- a/series_tiempo_ar_api/apps/api/query/strings.py
+++ b/series_tiempo_ar_api/apps/api/query/strings.py
@@ -1,5 +1,6 @@
 #! coding: utf-8
 
+from django.conf import settings
 
 ELASTICSEARCH_ERROR = u"Error Fatal. Contacte un administrador"
 SERIES_DOES_NOT_EXIST = u"Serie inexistente: {}"
@@ -13,6 +14,7 @@ INVALID_SERIES_IDS_FORMAT = u"Formato de series a seleccionar inválido"
 # Para el parámetro de IDS: rep mode ó agregación no reconocida
 INVALID_TRANSFORMATION = u"Transformación inválida: {}"
 
+SERIES_OVER_LIMIT = u"Cantidad de series pedidas por encima del límite permitido ({})"
 
 EMPTY_QUERY_ERROR = u"Query vacía, primero agregue una serie"
 INVALID_SORT_PARAMETER = u'"how" debe ser "asc", o "desc", recibido {}'

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
@@ -131,3 +131,14 @@ class IdsTest(TestCase):
         self.cmd.run(self.query, {'ids': ids})
 
         self.assertTrue(self.cmd.errors)
+
+    def test_series_over_limit(self):
+
+        ids_list = [SERIES_NAME] * (settings.MAX_ALLOWED_VALUES['ids'] + 1)
+        ids = ids_list[0]
+        for series_id in ids_list[1:]:
+            ids += ',' + series_id
+
+        self.cmd.run(self.query, {'ids': ids})
+
+        self.assertTrue(self.cmd.errors)


### PR DESCRIPTION
Closes #102 

Si llega un query con una cantidad por encima de ese límite (establecido en 20), se rechaza la operación y devuelve un error