### PR TITLE
Bugfix a transformación concatenada con end of period

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -131,7 +131,7 @@ params._agg.value = 0;
 EOP_MAP = """
 if (doc.timestamp.value > params._agg.last_date) {
     params._agg.last_date = doc.timestamp.value;
-    params._agg.value = doc.%s.value;
+    params._agg.value = doc.value.value;
 }
 """
 

--- a/series_tiempo_ar_api/apps/api/query/es_query/collapse_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/collapse_query.py
@@ -64,10 +64,9 @@ class CollapseQuery(BaseQuery):
                     interval=self.collapse_interval)
 
         if collapse_agg == constants.AGG_END_OF_PERIOD:
-            rep_mode = serie.rep_mode
             bucket.metric(constants.COLLAPSE_AGG_NAME, 'scripted_metric',
                           init_script=constants.EOP_INIT,
-                          map_script=constants.EOP_MAP % rep_mode,
+                          map_script=constants.EOP_MAP,
                           reduce_script=constants.EOP_REDUCE)
         else:
             bucket.metric(constants.COLLAPSE_AGG_NAME,

--- a/series_tiempo_ar_api/apps/api/tests/collapse_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/collapse_query_tests.py
@@ -279,3 +279,26 @@ class CollapseQueryTests(TestCase):
                               'end_of_period')
         self.query.add_collapse('year')
         self.query.run()
+
+    def test_end_of_period_with_rep_mode(self):
+        self.query.add_series(self.single_series,
+                              'percent_change',
+                              self.series_periodicity,
+                              'end_of_period')
+        self.query.add_collapse('year')
+        self.query.add_filter(start="1970")
+        data = self.query.run()
+
+        orig_eop = CollapseQuery(index=settings.TEST_INDEX)
+        orig_eop.add_series(self.single_series,
+                            self.rep_mode,
+                            self.series_periodicity,
+                            'end_of_period')
+        orig_eop.add_filter(start="1970")
+        orig_eop.add_collapse('year')
+        end_of_period = orig_eop.run()
+
+        for i, row in enumerate(data[1:], 1):  # El primero es nulo en pct change
+            value = end_of_period[i][1] / end_of_period[i - 1][1] - 1
+
+            self.assertAlmostEqual(value, row[1])


### PR DESCRIPTION
Closes #111 

Aplica primero la transformación end_of_period sobre el valor original de la serie, y *luego* la transformación pedida (change, pct_change, ...)