### PR TITLE
158 smtp config

### DIFF
--- a/conf/settings/api.py
+++ b/conf/settings/api.py
@@ -34,3 +34,6 @@ MAX_ALLOWED_VALUES = {
 
 
 DISTRIBUTION_INDEX_JOB_TIMEOUT = 500  # Segundos
+
+# Nombre del grupo de usuarios que reciben reportes de indexación
+READ_DATAJSON_RECIPIENT_GROUP = 'read_datajson_recipients'

--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -153,6 +153,7 @@ DJANGO_BASE_APPS = (
 VENDOR_APPS = (
     "django_rq",
     'import_export',
+    'des'
 )
 
 APPS = (
@@ -250,7 +251,7 @@ LOGGING = {
 }
 
 # EMAILS
-EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND', default='django.core.mail.backends.console.EmailBackend')
+EMAIL_BACKEND = 'des.backends.ConfiguredEmailBackend'
 
 
 DEFAULT_REDIS_HOST = env("DEFAULT_REDIS_HOST", default="localhost")

--- a/conf/settings/production.py
+++ b/conf/settings/production.py
@@ -40,9 +40,3 @@ RAVEN_CONFIG = {
 }
 
 INSTALLED_APPS += 'raven.contrib.django.raven_compat',
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = env('EMAIL_HOST', default="")
-EMAIL_HOST_USER = env('EMAIL_HOST_USER', default="")
-EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default="")
-EMAIL_USE_TLS = True

--- a/conf/settings/staging.py
+++ b/conf/settings/staging.py
@@ -37,9 +37,3 @@ RAVEN_CONFIG = {
 }
 
 INSTALLED_APPS = INSTALLED_APPS + ('raven.contrib.django.raven_compat',)
-
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = os.environ['EMAIL_HOST']
-EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
-EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
-EMAIL_USE_TLS = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,3 +14,4 @@ pyyaml
 django-ipware==1.1.6
 django-import-export==0.5.1
 python-crontab==2.2.8
+django-des==2.2.0

--- a/series_tiempo_ar_api/apps/management/migrations/read_datajson_group.py
+++ b/series_tiempo_ar_api/apps/management/migrations/read_datajson_group.py
@@ -1,0 +1,23 @@
+#! coding: utf-8
+
+from django.conf import settings
+from django.db import migrations
+from django.contrib.auth.models import Group
+
+
+def create_group(*_):
+    Group.objects.get_or_create(name=settings.READ_DATAJSON_RECIPIENT_GROUP)
+
+
+def delete_group(*_):
+    Group.objects.filter(name=settings.READ_DATAJSON_RECIPIENT_GROUP).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('management', '0012_readdatajsontask_stats'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_group, delete_group),
+    ]

--- a/series_tiempo_ar_api/apps/management/models.py
+++ b/series_tiempo_ar_api/apps/management/models.py
@@ -7,7 +7,7 @@ import sys
 import getpass
 
 from crontab import CronTab
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Group
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -149,7 +149,8 @@ class ReadDataJsonTask(models.Model):
         msg += self.format_message('distributions', 'Distribuciones')
         msg += self.format_message('fields', 'Series')
 
-        emails = [user.email for user in User.objects.filter(is_staff=True)]
+        recipients = Group.objects.get(name=settings.READ_DATAJSON_RECIPIENT_GROUP)
+        emails = [user.email for user in recipients.user_set.all()]
         subject = u'[{}] API Series de Tiempo: {}'.format(settings.ENV_TYPE,
                                                           str(self.created))
 

--- a/series_tiempo_ar_api/apps/management/tests/tasks_tests.py
+++ b/series_tiempo_ar_api/apps/management/tests/tasks_tests.py
@@ -1,7 +1,8 @@
 #!coding=utf8
 import os
 
-from django.contrib.auth.models import User
+from django.conf import settings
+from django.contrib.auth.models import User, Group
 from django.core import mail
 from django.core.management import call_command
 from django.test import TestCase
@@ -16,7 +17,8 @@ dir_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'samples')
 class ReadDataJsonTest(TestCase):
 
     def setUp(self):
-        User(username='test_user', password='test', email='test@test.com', is_staff=True).save()
+        self.user = User(username='test', password='test', email='test@test.com', is_staff=True)
+        self.user.save()
 
     def test_read(self):
         identifier = 'test_id'
@@ -68,6 +70,9 @@ class ReadDataJsonTest(TestCase):
              catalog_url=os.path.join(dir_path, 'sample_data.json'),
              indexable=True).save()
 
+        group = Group.objects.get(name=settings.READ_DATAJSON_RECIPIENT_GROUP)
+        self.user.groups.add(group)
+        self.user.save()
         call_command('read_datajson', no_async=True)
 
         self.assertEqual(len(mail.outbox), 1)

--- a/series_tiempo_ar_api/urls.py
+++ b/series_tiempo_ar_api/urls.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.conf.urls import url, include
 from django.conf.urls.static import static
 from django.contrib import admin
+from des import urls as des_urls
+
 
 admin.autodiscover()
 
@@ -12,5 +14,6 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^django-rq/', include('django_rq.urls')),
     url(r'^api/', include('series_tiempo_ar_api.apps.api.urls', namespace="api")),
-    url(r'^analytics/', include('series_tiempo_ar_api.apps.analytics.urls', namespace='analytics'))
+    url(r'^analytics/', include('series_tiempo_ar_api.apps.analytics.urls', namespace='analytics')),
+    url(r'^django-des/', include(des_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Agrega [`des`](https://github.com/jamiecounsell/django-des) a la aplicación, permite configurar el servidor SMTP usado desde el django admin.

Cambia la lógica de la generación del reporte para solo mandar mails a los usuarios dentro de un grupo `read_datajson_recipients` en vez de los usuarios taggeados como "staff".
