### PR TITLE
Indicadores de serie 2

### DIFF
--- a/series_tiempo_ar_api/apps/management/models.py
+++ b/series_tiempo_ar_api/apps/management/models.py
@@ -164,17 +164,6 @@ class ReadDataJsonTask(models.Model):
             task.logs += msg + '\n'
             task.save()
 
-    @classmethod
-    def increment_indicator(cls, task, catalog_id, indicator_type, amt=1):
-        with transaction.atomic():
-            task = cls.objects.select_for_update().get(id=task.id)
-            indicator = task.indicator_set.get_or_create(
-                type=indicator_type,
-                node=Node.objects.get(catalog_id=catalog_id)
-            )[0]
-            indicator.value += amt
-            indicator.save()
-
 
 class Indicator(models.Model):
 

--- a/series_tiempo_ar_api/libs/indexing/catalog_reader.py
+++ b/series_tiempo_ar_api/libs/indexing/catalog_reader.py
@@ -40,11 +40,12 @@ def index_catalog(node, task, read_local=False, whitelist=False):
         catalog_model[0].save()
 
     Dataset.objects.filter(catalog__identifier=node.catalog_id).update(present=False, updated=False)
+    # Borro de la lista de indexables a los datasets que ya no están presentes en el catálogo
     dataset_ids = [dataset['identifier'] for dataset in catalog.get_datasets()]
     Dataset.objects.filter(~Q(identifier__in=dataset_ids)).update(indexable=False)
+
     Distribution.objects.filter(dataset__catalog__identifier=node.catalog_id).update(updated=False)
     Field.objects.filter(distribution__dataset__catalog=catalog_model).update(updated=False)
-    IndicatorLoader().clear_indicators()
     for distribution in catalog.get_distributions(only_time_series=True):
         identifier = distribution['identifier']
         index_distribution.delay(identifier, node.id, task, read_local, whitelist)

--- a/series_tiempo_ar_api/libs/indexing/catalog_reader.py
+++ b/series_tiempo_ar_api/libs/indexing/catalog_reader.py
@@ -3,10 +3,12 @@ from __future__ import division
 
 import json
 
+from django.db.models import Q
 from pydatajson import DataJson
 
 from series_tiempo_ar_api.apps.api.models import Dataset, Catalog, Distribution, Field
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask
+from series_tiempo_ar_api.libs.indexing.report.indicators import IndicatorLoader
 from series_tiempo_ar_api.libs.indexing.tasks import index_distribution
 from .strings import READ_ERROR
 
@@ -38,9 +40,11 @@ def index_catalog(node, task, read_local=False, whitelist=False):
         catalog_model[0].save()
 
     Dataset.objects.filter(catalog__identifier=node.catalog_id).update(present=False, updated=False)
+    dataset_ids = [dataset['identifier'] for dataset in catalog.get_datasets()]
+    Dataset.objects.filter(~Q(identifier__in=dataset_ids)).update(indexable=False)
     Distribution.objects.filter(dataset__catalog__identifier=node.catalog_id).update(updated=False)
     Field.objects.filter(distribution__dataset__catalog=catalog_model).update(updated=False)
-
+    IndicatorLoader().clear_indicators()
     for distribution in catalog.get_distributions(only_time_series=True):
         identifier = distribution['identifier']
         index_distribution.delay(identifier, node.id, task, read_local, whitelist)

--- a/series_tiempo_ar_api/libs/indexing/database_loader.py
+++ b/series_tiempo_ar_api/libs/indexing/database_loader.py
@@ -65,7 +65,7 @@ class DatabaseLoader(object):
         catalog = catalog.copy()
         # Borro el dataset, de existir. Solo guardo metadatos
         catalog.pop(constants.DATASET, None)
-        catalog_model, created = Catalog.objects.get_or_create(identifier=catalog_id)
+        catalog_model = Catalog.objects.get(identifier=catalog_id)
 
         catalog = self._remove_blacklisted_fields(
             catalog,
@@ -74,9 +74,7 @@ class DatabaseLoader(object):
         catalog_meta = json.dumps(catalog)
 
         catalog_model.title = catalog.get(constants.FIELD_TITLE)
-        if created:
-            self.increment_indicator(Indicator.CATALOG_NEW)
-        elif catalog_model.metadata != catalog_meta:
+        if catalog_model.metadata != catalog_meta:
             catalog_model = self.set_as_updated(catalog_model)
 
         catalog_model.metadata = catalog_meta
@@ -93,12 +91,10 @@ class DatabaseLoader(object):
         # Borro las distribuciones, de existir. Solo guardo metadatos
         dataset.pop(constants.DISTRIBUTION, None)
         identifier = dataset[constants.IDENTIFIER]
-        dataset_model, created = Dataset.objects.get_or_create(
+        dataset_model = Dataset.objects.get(
             identifier=identifier,
             catalog=self.catalog_model,
         )
-        if created:
-            dataset_model.indexable = self.default_whitelist
 
         dataset = self._remove_blacklisted_fields(
             dataset,
@@ -107,9 +103,7 @@ class DatabaseLoader(object):
         dataset_meta = json.dumps(dataset)
         dataset_model.present = True
 
-        if created:
-            self.increment_indicator(Indicator.DATASET_NEW)
-        elif dataset_meta != dataset_model.metadata:
+        if dataset_meta != dataset_model.metadata:
             dataset_model = self.set_as_updated(dataset_model)
 
         dataset_model.metadata = dataset_meta

--- a/series_tiempo_ar_api/libs/indexing/report/indicators.py
+++ b/series_tiempo_ar_api/libs/indexing/report/indicators.py
@@ -1,0 +1,25 @@
+#! coding: utf-8
+from redis import Redis
+
+from series_tiempo_ar_api.apps.management.models import Indicator, Node
+
+
+class IndicatorLoader(object):
+
+    def __init__(self):
+        self.redis = Redis()
+
+    def load_indicators(self, task):
+        for node in Node.objects.filter(indexable=True):
+            for indicator, _ in Indicator.TYPE_CHOICES:
+                value = self.redis.get(node.catalog_id + indicator)
+                if value:
+                    task.indicator_set.create(type=indicator, value=value, node=node)
+
+    def increment_indicator(self, catalog_id, indicator, amt=1):
+        self.redis.incr(catalog_id + indicator, amt)
+
+    def clear_indicators(self):
+        for node in Node.objects.all():
+            for indicator, _ in Indicator.TYPE_CHOICES:
+                self.redis.delete(node.catalog_id + indicator)

--- a/series_tiempo_ar_api/libs/indexing/report/indicators.py
+++ b/series_tiempo_ar_api/libs/indexing/report/indicators.py
@@ -1,6 +1,7 @@
 #! coding: utf-8
 from redis import Redis
 
+from django.conf import settings
 from series_tiempo_ar_api.apps.management.models import Indicator, Node
 
 
@@ -8,7 +9,9 @@ class IndicatorLoader(object):
     """Lee y escribe valores de indicadores al store de Redis"""
 
     def __init__(self):
-        self.redis = Redis()
+        self.redis = Redis(host=settings.DEFAULT_REDIS_HOST,
+                           port=settings.DEFAULT_REDIS_PORT,
+                           db=int(settings.DEFAULT_REDIS_DB))
 
     def load_indicators_into_db(self, task):
         """Carga todas las variables de indicadores guardadas a la base de datos en modelos Indicator,

--- a/series_tiempo_ar_api/libs/indexing/report/report_generator.py
+++ b/series_tiempo_ar_api/libs/indexing/report/report_generator.py
@@ -20,6 +20,7 @@ class ReportGenerator(object):
 
     def __init__(self, task):
         self.task = task
+        self.indicators_loader = IndicatorLoader()
 
     def generate(self):
         self.task.finished = timezone.now()
@@ -28,6 +29,7 @@ class ReportGenerator(object):
         self.persist_indicators()
         self.calculate_indicators()
         self.generate_email()
+        self.indicators_loader.clear_indicators()
 
     def generate_email(self):
         start_time = self._format_date(self.task.created)
@@ -142,4 +144,4 @@ class ReportGenerator(object):
         self.task.indicator_set.create(type=Indicator.FIELD_NOT_UPDATED, value=not_updated, node=node)
 
     def persist_indicators(self):
-        IndicatorLoader().load_indicators(self.task)
+        self.indicators_loader.load_indicators_into_db(self.task)

--- a/series_tiempo_ar_api/libs/indexing/report/report_generator.py
+++ b/series_tiempo_ar_api/libs/indexing/report/report_generator.py
@@ -134,15 +134,15 @@ class ReportGenerator(object):
         total = self.task.indicator_set.filter(type=Indicator.FIELD_TOTAL)
         total = total[0].value if total else 0
 
-        updated = Field.objects.filter(distribution__dataset__catalog=catalog, updated=True).count()
-        self.task.indicator_set.create(type=Indicator.FIELD_UPDATED, value=updated, node=node)
-
-        not_updated = total - updated
-        self.task.indicator_set.create(type=Indicator.FIELD_NOT_UPDATED, value=not_updated, node=node)
-
         indexable = Field.objects.filter(distribution__dataset__catalog=catalog,
                                          distribution__dataset__indexable=True).count()
         self.task.indicator_set.create(type=Indicator.FIELD_INDEXABLE, value=indexable, node=node)
 
         not_indexable = total - indexable
         self.task.indicator_set.create(type=Indicator.FIELD_NOT_INDEXABLE, value=not_indexable, node=node)
+        updated = Field.objects.filter(distribution__dataset__catalog=catalog, updated=True).count()
+
+        self.task.indicator_set.create(type=Indicator.FIELD_UPDATED, value=updated, node=node)
+
+        not_updated = indexable - updated
+        self.task.indicator_set.create(type=Indicator.FIELD_NOT_UPDATED, value=not_updated, node=node)

--- a/series_tiempo_ar_api/libs/indexing/tasks.py
+++ b/series_tiempo_ar_api/libs/indexing/tasks.py
@@ -4,7 +4,6 @@ import json
 from django.conf import settings
 from django_rq import job, get_queue
 from pydatajson import DataJson
-from redis import Redis
 
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask, Node, Indicator
 from series_tiempo_ar_api.apps.api.models import Dataset, Catalog
@@ -22,31 +21,12 @@ def index_distribution(distribution_id, node_id, task,
     node = Node.objects.get(id=node_id)
     catalog = DataJson(json.loads(node.catalog))
     distribution = catalog.get_distribution(identifier=distribution_id)
-    catalog_model, created = Catalog.objects.get_or_create(identifier=node.catalog_id)
-    if created:
-        IndicatorLoader().increment_indicator(node.catalog_id, Indicator.CATALOG_NEW)
-        catalog_model.title = catalog['title']
-        catalog_model.identifier = node.catalog_id
-        catalog_model.save()
-
-    dataset_model, created = Dataset.objects.get_or_create(
-        identifier=distribution['dataset_identifier'],
-        catalog=catalog_model,
-    )
-
-    if created:
-        IndicatorLoader().increment_indicator(node.catalog_id, Indicator.DATASET_NEW)
-        dataset_model.indexable = whitelist
-        dataset_model.metadata = '{}'
-
-    dataset_model.present = True
-    dataset_model.save()
+    dataset_model = get_dataset(catalog, node.catalog_id, distribution['dataset_identifier'], whitelist)
     if not dataset_model.indexable:
         return
 
     try:
-        scraper = Scraper(read_local)
-        result = scraper.run(distribution, catalog)
+        result = Scraper(read_local).run(distribution, catalog)
         if not result:
             return
 
@@ -66,6 +46,29 @@ def index_distribution(distribution_id, node_id, task,
 
         if settings.RQ_QUEUES['indexing'].get('ASYNC', True):
             raise e  # Django-rq / sentry logging
+
+
+def get_dataset(catalog, catalog_id, dataset_id, whitelist):
+    catalog_model, created = Catalog.objects.get_or_create(identifier=catalog_id)
+    if created:
+        IndicatorLoader().increment_indicator(catalog_id, Indicator.CATALOG_NEW)
+        catalog_model.title = catalog['title']
+        catalog_model.identifier = catalog_id
+        catalog_model.save()
+
+    dataset_model, created = Dataset.objects.get_or_create(
+        identifier=dataset_id,
+        catalog=catalog_model,
+    )
+
+    if created:
+        IndicatorLoader().increment_indicator(catalog_id, Indicator.DATASET_NEW)
+        dataset_model.indexable = whitelist
+        dataset_model.metadata = '{}'
+
+    dataset_model.present = True
+    dataset_model.save()
+    return dataset_model
 
 
 # Para correr con el scheduler

--- a/series_tiempo_ar_api/libs/indexing/tasks.py
+++ b/series_tiempo_ar_api/libs/indexing/tasks.py
@@ -37,8 +37,9 @@ def index_distribution(distribution_id, node_id, task,
         ReadDataJsonTask.increment_indicator(task, node.catalog_id, Indicator.DATASET_NEW)
         dataset_model.indexable = whitelist
         dataset_model.metadata = '{}'
-        dataset_model.save()
 
+    dataset_model.present = True
+    dataset_model.save()
     if not dataset_model.indexable:
         return
 

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -175,12 +175,6 @@ class ReaderTests(TestCase):
         # La distribución fue indexada nuevamente, está marcada como indexable
         self.assertTrue(distribution.indexable)
 
-    def test_field_indicators_first_run(self):
-        index_catalog(self.node, self.task, read_local=True, whitelist=True)
-
-        # Esperado: 3 fields nuevos
-        self.assertEqual(self.task.indicator_set.get(type=Indicator.FIELD_NEW).value, 3)
-
     def test_error_distribution_logs(self):
         catalog = os.path.join(SAMPLES_DIR, 'distribution_missing_downloadurl.json')
         self.node.catalog_url = catalog

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -8,7 +8,7 @@ from elasticsearch_dsl import Search
 from pydatajson import DataJson
 from series_tiempo_ar.search import get_time_series_distributions
 
-from series_tiempo_ar_api.apps.api.models import Distribution, Field
+from series_tiempo_ar_api.apps.api.models import Distribution, Field, Catalog, Dataset
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask, Node, Indicator
 from series_tiempo_ar_api.libs.indexing.catalog_reader import index_catalog
 from series_tiempo_ar_api.libs.indexing.database_loader import \
@@ -106,6 +106,21 @@ class IndexerTests(TestCase):
                         indexable=True)
         node.save()
         catalog = DataJson(json.loads(node.catalog))
+        catalog_model, created = Catalog.objects.get_or_create(identifier=node.catalog_id)
+        if created:
+            catalog_model.title = catalog['title'],
+            catalog_model.metadata = '{}'
+            catalog_model.save()
+        for dataset in catalog.get_datasets(only_time_series=True):
+            dataset_model, created = Dataset.objects.get_or_create(
+                catalog=catalog_model,
+                identifier=dataset['identifier']
+            )
+            if created:
+                dataset_model.metadata = '{}'
+                dataset_model.indexable = True
+                dataset_model.save()
+
         distributions = get_time_series_distributions(catalog)
         db_loader = DatabaseLoader(self.task, read_local=True, default_whitelist=True)
         for distribution in distributions:
@@ -161,7 +176,7 @@ class ReaderTests(TestCase):
         self.assertTrue(distribution.indexable)
 
     def test_field_indicators_first_run(self):
-        index_catalog(self.node, self.task, read_local=True)
+        index_catalog(self.node, self.task, read_local=True, whitelist=True)
 
         # Esperado: 3 fields nuevos
         self.assertEqual(self.task.indicator_set.get(type=Indicator.FIELD_NEW).value, 3)
@@ -170,6 +185,6 @@ class ReaderTests(TestCase):
         catalog = os.path.join(SAMPLES_DIR, 'distribution_missing_downloadurl.json')
         self.node.catalog_url = catalog
         self.node.save()
-        index_catalog(self.node, self.task, read_local=True)
+        index_catalog(self.node, self.task, read_local=True, whitelist=True)
 
         self.assertGreater(len(ReadDataJsonTask.objects.get(id=self.task.id).logs), 10)


### PR DESCRIPTION
Closes #207 

Modifica el comportamiento del cálculo de indicadores:
- Los valores de series no actualizadas se calcula sobre la cantidad de series indexables en vez de las totales
- Se guardan los indicadores en la instancia de Redis, y luego se persisten en la base de datos relacional
