### PR TITLE
Indexación automática de metadatos

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/management/commands/index_metadata.py
+++ b/series_tiempo_ar_api/apps/metadata/management/commands/index_metadata.py
@@ -4,6 +4,7 @@ import logging
 from django.core.management import BaseCommand
 from pydatajson import DataJson
 
+from series_tiempo_ar_api.apps.management.models import Node
 from series_tiempo_ar_api.apps.metadata.indexer.metadata_indexer import MetadataIndexer
 
 
@@ -13,11 +14,17 @@ logger = logging.getLogger(__name__)
 class Command(BaseCommand):
 
     def add_arguments(self, parser):
-        parser.add_argument('datajson_url')
+        parser.add_argument('datajson_url', nargs='*')
 
     def handle(self, *args, **options):
-        try:
-            data_json = DataJson(options['datajson_url'])
-            MetadataIndexer(data_json).index()
-        except Exception as e:
-            logger.exception(u'Error en la lectura del catálogo: %s', e)
+        if options['datajson_url']:
+            urls = options['datajson_url']
+        else:
+            urls = [node.catalog_url for node in Node.objects.filter(indexable=True)]
+
+        for url in urls:
+            try:
+                data_json = DataJson(url)
+                MetadataIndexer(data_json).index()
+            except Exception as e:
+                logger.exception(u'Error en la lectura del catálogo: %s', e)


### PR DESCRIPTION
Modifica `index_metadata` para leer múltiples URLs, o si ninguna es especificada, leer las URLs desde los modelos Node de la base de datos. Necesario para facilitar la automatización de correr este comando periódicamente