### PR TITLE
Exporto analytics de manera sincrónica

### DIFF
--- a/series_tiempo_ar_api/apps/analytics/templates/admin/analytics/change_list.html
+++ b/series_tiempo_ar_api/apps/analytics/templates/admin/analytics/change_list.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_list.html" %}
 
 {% block object-tools-items %}
-    <li><a href="{% url 'analytics:export_analytics' %}" class="link">EXPORT TO CSV</a></li>
+    <li><a href="{% url 'analytics:read_analytics' %}" class="link">EXPORT TO CSV</a></li>
     {{ block.super }}
 
 {% endblock %}

--- a/series_tiempo_ar_api/apps/analytics/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/analytics/tests/view_tests.py
@@ -11,23 +11,6 @@ from django.contrib.auth.models import User
 samples_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'samples')
 
 
-class ExportViewTests(TestCase):
-
-    def test_export_when_not_staff(self):
-        response = self.client.get(reverse('analytics:export_analytics'))
-
-        # Expected: admin login redirect
-        self.assertEqual(response.status_code, 302)
-
-    def test_export_as_staff(self):
-        user = User(username='user', password='pass', email='mail@test.com', is_staff=True)
-        user.save()
-        self.client.force_login(user)
-        response = self.client.get(reverse('analytics:export_analytics'))
-
-        self.assertEqual(response.status_code, 200)
-
-
 class AnalyticsDownloadTests(TestCase):
 
     def test_download_when_not_staff(self):

--- a/series_tiempo_ar_api/apps/analytics/urls.py
+++ b/series_tiempo_ar_api/apps/analytics/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
-from .views import save, read_analytics, export_analytics
+from .views import save, export_analytics
 
 urlpatterns = [
     url('^save/$', save, name='save'),
-    url('^analytics.csv', read_analytics, name='read_analytics'),
+    url('^analytics.csv', export_analytics, name='read_analytics'),
     url('^export', export_analytics, name='export_analytics'),
 ]

--- a/series_tiempo_ar_api/apps/analytics/urls.py
+++ b/series_tiempo_ar_api/apps/analytics/urls.py
@@ -4,5 +4,4 @@ from .views import save, export_analytics
 urlpatterns = [
     url('^save/$', save, name='save'),
     url('^analytics.csv', export_analytics, name='read_analytics'),
-    url('^export', export_analytics, name='export_analytics'),
 ]

--- a/series_tiempo_ar_api/apps/analytics/views.py
+++ b/series_tiempo_ar_api/apps/analytics/views.py
@@ -9,7 +9,6 @@ from django.http import HttpResponse
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.admin.views.decorators import staff_member_required
-from django.shortcuts import render
 
 from .tasks import analytics, export
 
@@ -42,11 +41,9 @@ def save(request):
 
 
 @staff_member_required
-def read_analytics(request):
-    return sendfile.sendfile(request, os.path.join(settings.PROTECTED_MEDIA_DIR, 'analytics.csv'))
-
-
-@staff_member_required
 def export_analytics(request):
-    export.delay()
-    return HttpResponse(render(request, 'export.html'))
+    export()
+    return sendfile.sendfile(request,
+                             os.path.join(settings.PROTECTED_MEDIA_DIR, 'analytics.csv'),
+                             attachment=True,
+                             attachment_filename='data.csv')


### PR DESCRIPTION
Closes #231 

El endpoint de descarga de analytics (`/analytics/analytics.csv`) ahora pasa a generar el .csv de manera sincrónica. Este comportamiento es temporal hasta migrar los analytics fuera del proyecto, porque esta generación no escala.
