### PR TITLE
query: fix a los datos devueltos cuando se pide una misma serie dos v…

### DIFF
--- a/series_tiempo_ar_api/apps/api/tests/es_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/es_query_tests.py
@@ -384,3 +384,22 @@ class QueryTest(TestCase):
         for row in data:
             self.assertIsNotNone(row[2])
             self.assertIsNone(row[1])
+
+    def test_same_series_rep_mode(self):
+        self.query.add_series(self.single_series, self.rep_mode, self.series_periodicity)
+        self.query.add_series(self.single_series, 'percent_change_a_year_ago', self.series_periodicity)
+
+        data = self.query.run()
+
+        other_query = ESQuery(settings.TEST_INDEX)
+        other_query.add_series(self.single_series, 'percent_change_a_year_ago', self.series_periodicity)
+        other_query.add_series(self.single_series, self.rep_mode, self.series_periodicity)
+
+        other_data = other_query.run()
+
+        # Esperado: mismos resultados, invertidos en orden de fila
+        for i, row in enumerate(data):
+            other_row = other_data[i]
+            self.assertEqual(row[0], other_row[0])
+            self.assertEqual(row[1], other_row[2])
+            self.assertEqual(row[2], other_row[1])


### PR DESCRIPTION
…eces con distintos modos de representación

Ejemplo:
si se pedía la serie A dos veces, una vez con rep_mode `value` (default) y otra con `change`, los resultados se guardaban en un diccionario con keys = `series_id`, con la siguiente estructura
```
{
  "timestamp1": { "A": "valor1" },
  "timestamp2": { "A": "valor2"},
  ...
}
```
Los datos de ambas series se guardaban bajo keys = `A`, se pisaban entre sí.
Ahora se guardan usando una combinación de `series_id` + `rep_mode` + `collapse_agg`, para solo haya colisiones si realmente son los mismos datos