### PR TITLE
Borro los none de la respuesta CSV

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/response.py
+++ b/series_tiempo_ar_api/apps/api/query/response.py
@@ -60,10 +60,11 @@ class CSVFormatter(BaseFormatter):
         header = [settings.INDEX_COLUMN] + series_ids
 
         writer.writerow(header)
-        decimal_char = query_args.get(constants.PARAM_DEC_CHAR)
-        if decimal_char:  # Reemplazo los puntos decimales por el char pedido
+        decimal_char = query_args.get(constants.PARAM_DEC_CHAR, '.')
+        if decimal_char != '.':
+            # Reemplazo los puntos decimales por el char pedido
             for row in data:
-                row = [str(el).replace('.', decimal_char) for el in row]
+                row = [str(el).replace('.', decimal_char) if el else None for el in row]
                 writer.writerow(row)
         else:
             for row in data:

--- a/series_tiempo_ar_api/apps/api/tests/response_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/response_tests.py
@@ -64,3 +64,15 @@ class ResponseTests(TestCase):
         line_end = response.content.find('\n')
         header = response.content[:line_end]
         self.assertIn(self.series_desc, header)
+
+    def test_csv_different_decimal_empty_rows(self):
+        query = Query(index=settings.TEST_INDEX)
+
+        field = Field.objects.get(series_id=self.single_series)
+        query.add_series(self.single_series, field)
+        query.add_series(self.single_series, field, rep_mode='percent_change_a_year_ago')
+
+        generator = ResponseFormatterGenerator('csv').get_formatter()
+        response = generator.run(query, {'decimal': ','})
+
+        self.assertFalse("None" in response.content)


### PR DESCRIPTION
Este fenómeno solo ocurre cuando se setea el caracter decimal de los valores a algo no default.

Antes: se casteaba el None a `str` y se mostraba en la respuesta CSV

2015-04-01,"0,066"
2015-07-01,"0,059"
2015-10-01,None
2016-01-01,None
2016-04-01,"0,093"
2016-07-01,"0,085"

Ahora: se chequea por None y no se castea si el valor es nulo

2015-04-01,"0,066"
2015-07-01,"0,059"
2015-10-01,
2016-01-01,
2016-04-01,"0,093"
2016-07-01,"0,085"