### PR TITLE
Corrijo timezone de fechas exportadas en analytics

### DIFF
--- a/series_tiempo_ar_api/apps/analytics/tasks.py
+++ b/series_tiempo_ar_api/apps/analytics/tasks.py
@@ -5,7 +5,7 @@ import json
 import unicodecsv
 from django.conf import settings
 from django_rq import job
-
+from django.utils.timezone import localtime
 from .models import Query
 from .utils import kong_milliseconds_to_tzdatetime
 
@@ -23,17 +23,17 @@ def export(path=None):
     queryset = Query.objects.all()
     filepath = path or os.path.join(settings.PROTECTED_MEDIA_DIR, settings.ANALYTICS_CSV_FILENAME)
 
-    fields = [
-        Query.timestamp,
-        Query.ip_address,
-        Query.ids,
-        Query.params
-    ]
+    fields = {
+        'timestamp': lambda x: localtime(x.timestamp),
+        'ip_address': lambda x: x.ip_address,
+        'ids': lambda x: x.ids,
+        'params': lambda x: x.params,
+    }
 
     with open(filepath, 'wb') as f:
         writer = unicodecsv.writer(f)
         # header
-        writer.writerow([field.field_name for field in fields])
+        writer.writerow([field for field in fields.keys()])
         for query in queryset.iterator():
 
-            writer.writerow([getattr(query, field.field_name) for field in fields])
+            writer.writerow([val(query) for val in fields.values()])

--- a/series_tiempo_ar_api/apps/analytics/tasks.py
+++ b/series_tiempo_ar_api/apps/analytics/tasks.py
@@ -3,8 +3,8 @@ import os
 import json
 
 import unicodecsv
-from django.conf import settings
 from django_rq import job
+from django.conf import settings
 from django.utils.timezone import localtime
 from .models import Query
 from .utils import kong_milliseconds_to_tzdatetime

--- a/series_tiempo_ar_api/apps/analytics/tests/export_tests.py
+++ b/series_tiempo_ar_api/apps/analytics/tests/export_tests.py
@@ -1,6 +1,9 @@
 #!coding=utf8
 import os
 
+import unicodecsv
+from django.utils.timezone import localtime
+from iso8601 import iso8601
 from django.test import TestCase
 from django.utils import timezone
 
@@ -30,3 +33,16 @@ class ExportTests(TestCase):
     def tearDown(self):
         if os.path.exists(self.filepath):
             os.remove(self.filepath)
+
+    def test_export_dates(self):
+        query = Query(args='test', params='test', ip_address='ip_addr', timestamp=timezone.now(), ids='')
+        query.save()
+
+        export(path=self.filepath)
+        with open(self.filepath) as f:
+            reader = unicodecsv.reader(f)
+            reader.next()
+            for line in unicodecsv.reader(f):
+                date = iso8601.parse_date(line[0])
+                # Timestamp del modelo en UTC, pasandola a localtime debe ser igual a la del CSV
+                self.assertEqual(localtime(query.timestamp), date)


### PR DESCRIPTION
Closes #212 

Se les aplica `localtime` de utils de django antes de ser escritas al CSV.

Además se cambia un poco la lógica de la escritura del CSV para poder aplicarle funciones a cada campo a exportar