### PR TITLE
Indexación de algunos metadatos en elasticsearch

### DIFF
--- a/series_tiempo_ar_api/libs/indexing/constants.py
+++ b/series_tiempo_ar_api/libs/indexing/constants.py
@@ -47,7 +47,8 @@ MAPPING = {
         "series_id": {"type": "keyword"},
         "aggregation": {"type": "keyword"},
         "interval": {"type": "keyword"},
-        "raw_value": {"type": "boolean"},
+        "raw_value": {"type": "boolean"},  # True si el doc tiene el value original de la serie
+        "catalog": {"type": "keyword"},  # catalog identifier de la fuente de los datos
     },
     "_all": {"enabled": False},
     "dynamic": "strict"

--- a/series_tiempo_ar_api/libs/indexing/constants.py
+++ b/series_tiempo_ar_api/libs/indexing/constants.py
@@ -47,6 +47,7 @@ MAPPING = {
         "series_id": {"type": "keyword"},
         "aggregation": {"type": "keyword"},
         "interval": {"type": "keyword"},
+        "raw_value": {"type": "boolean"},
     },
     "_all": {"enabled": False},
     "dynamic": "strict"

--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -22,6 +22,12 @@ class DistributionIndexer:
         self.elastic = ElasticInstance.get()
         self.index = index
 
+        self.init_index()
+
+    def init_index(self):
+        if not self.elastic.indices.exists(index=self.index):
+            self.elastic.indices.create(index=self.index, body=constants.INDEX_CREATION_BODY)
+
     def run(self, distribution):
         fields = distribution.field_set.all()
         fields = {field.title: field.identifier for field in fields}

--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -42,6 +42,7 @@ class DistributionIndexer:
         # List flatten: si el resultado son múltiples listas las junto en una sola
         actions = reduce(lambda x, y: x + y, result) if isinstance(result[0], list) else result
 
+        self.add_catalog_keyword(actions, distribution)
         for success, info in parallel_bulk(self.elastic, actions):
             if not success:
                 logger.warning(strings.BULK_REQUEST_ERROR, info)
@@ -80,6 +81,10 @@ class DistributionIndexer:
                                       freq=constants.BUSINESS_DAILY_FREQ)
 
         return pd.DataFrame(index=new_index, data=data, columns=columns)
+
+    def add_catalog_keyword(self, actions, distribution):
+        for action in actions:
+            action['_source']['catalog'] = distribution.dataset.catalog.identifier
 
 
 def get_time_index_periodicity(distribution, fields):

--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -21,8 +21,6 @@ class DistributionIndexer:
     def __init__(self, index):
         self.elastic = ElasticInstance.get()
         self.index = index
-        self.indexed_fields = set()
-        self.bulk_actions = []
 
     def run(self, distribution):
         fields = distribution.field_set.all()
@@ -66,7 +64,7 @@ class DistributionIndexer:
         columns = [fields[name] for name in df.columns]
 
         data = df.values
-        freq = freq_iso_to_pandas(self.get_time_index_periodicity(distribution, fields))
+        freq = freq_iso_to_pandas(get_time_index_periodicity(distribution, fields))
         new_index = pd.date_range(df.index[0], df.index[-1], freq=freq)
 
         # Chequeo de series de días hábiles (business days)
@@ -77,9 +75,10 @@ class DistributionIndexer:
 
         return pd.DataFrame(index=new_index, data=data, columns=columns)
 
-    def get_time_index_periodicity(self, distribution, fields):
-        time_index = distribution.field_set.get(identifier=fields['indice_tiempo'])
-        fields.pop('indice_tiempo')
-        periodicity = json.loads(time_index.metadata)['specialTypeDetail']
-        distribution.enhanced_meta.update_or_create(key=meta_keys.PERIODICITY, value=periodicity)
-        return periodicity
+
+def get_time_index_periodicity(distribution, fields):
+    time_index = distribution.field_set.get(identifier=fields['indice_tiempo'])
+    fields.pop('indice_tiempo')
+    periodicity = json.loads(time_index.metadata)['specialTypeDetail']
+    distribution.enhanced_meta.update_or_create(key=meta_keys.PERIODICITY, value=periodicity)
+    return periodicity

--- a/series_tiempo_ar_api/libs/indexing/indexer/operations.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/operations.py
@@ -97,6 +97,8 @@ def process_column(col, index):
         actions.extend(avg.values.flatten())
 
         if orig_freq == freq:
+            for row in actions:  # Marcamos a estos datos como los originales
+                row['_source']['raw_value'] = True
             break
 
         # Suma

--- a/series_tiempo_ar_api/libs/indexing/indexer/operations.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/operations.py
@@ -97,7 +97,7 @@ def process_column(col, index):
         actions.extend(avg.values.flatten())
 
         if orig_freq == freq:
-            for row in actions:  # Marcamos a estos datos como los originales
+            for row in avg:  # Marcamos a estos datos como los originales
                 row['_source']['raw_value'] = True
             break
 

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -101,6 +101,24 @@ class IndexerTests(TestCase):
 
         self.assertTrue(len(results))
 
+    def test_original_value_flag(self):
+        self._index_catalog('distribution_daily_periodicity.json')
+
+        results = Search(using=self.elastic,
+                         index=self.test_index) \
+            .filter('match', raw_value=True).execute()
+
+        self.assertTrue(len(results))
+
+    def test_catalog_value_indexed(self):
+        self._index_catalog('distribution_daily_periodicity.json')
+
+        results = Search(using=self.elastic,
+                         index=self.test_index) \
+            .filter('match', catalog=CATALOG_ID).execute()
+
+        self.assertTrue(len(results))
+
     @classmethod
     def tearDownClass(cls):
         pass

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -31,7 +31,6 @@ class IndexerTests(TestCase):
         self.task = ReadDataJsonTask()
         self.task.save()
         self.tearDown()
-        self.elastic.indices.create(self.test_index)
 
     def test_init_dataframe_columns(self):
         self._index_catalog('full_ts_data.json')
@@ -39,7 +38,7 @@ class IndexerTests(TestCase):
         distribution = Distribution.objects.get(identifier="212.1")
         fields = distribution.field_set.all()
         fields = {field.title: field.identifier for field in fields}
-        df = DistributionIndexer(None).init_df(distribution, fields)
+        df = DistributionIndexer(self.test_index).init_df(distribution, fields)
 
         for field in fields.values():
             self.assertTrue(field in df.columns)


### PR DESCRIPTION
Agrego dos campos al mapping de series de tiempo, `raw_value` que indica si el valor indexado es el original encontrado en una serie de tiempo (True) o es una agregación de los valores originales (False), y `catalog`, un keyword que indica el catálogo del que proviene el dato.

Estos campos serán usados para facilitar la generación del dump (#254)