### PR TITLE
Cambios a la respuesta de metadatos de series

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -123,6 +123,13 @@ La API de Series de Tiempo permite obtener datos de una o más series, permitien
         <td>.</td>
         <td>metadata=,</td>
     </tr>
+    <tr>
+        <td>flatten</td>
+        <td>No</td>
+        <td>Aplana la respuesta de metadatos en un objeto con un único nivel. No es necesario darle valor</td>
+        <td></td>
+        <td>flatten</td>
+    </tr>
 </table>
 
 ### `ids`
@@ -296,4 +303,28 @@ Las opciones disponibles son:
 * *,*: Coma.
 * *.*: Punto.
 
+### `flatten`
 
+Especifica si la respuesta de los metadatos de las series pedidas deberían devolverse en una jerarquía _plana_.
+
+Cuando el parámetro no es incluido, la respuesta tiene la siguiente estructura:
+```json
+    {
+        "catalog": [<catalog_meta>],
+        "dataset": [<dataset_meta>],
+        "distribution": [<distribution_meta>],
+        "field": [<field_meta>],
+    }
+```
+
+Una query con parámetro flatten incluido tendrá la siguiente respuesta de metadatos:
+
+```json
+    {
+        catalog_meta1: ...,
+        catalog_meta2: ...,
+        dataset_meta1: ...,
+        <nivel>_<meta_key>: <meta_value>
+        ...
+    }
+```

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -49,6 +49,7 @@ PARAM_START_DATE = 'start_date'
 PARAM_END_DATE = 'end_date'
 PARAM_DELIM = 'sep'
 PARAM_DEC_CHAR = 'decimal'
+PARAM_FLATTEN = 'flatten'
 
 METADATA_SIMPLE = 'simple'
 METADATA_FULL = 'full'

--- a/series_tiempo_ar_api/apps/api/query/pipeline.py
+++ b/series_tiempo_ar_api/apps/api/query/pipeline.py
@@ -360,6 +360,11 @@ class Collapse(BaseOperation):
 class Metadata(BaseOperation):
 
     def run(self, query, args):
+        self.check_meta(query, args)
+        if args.get(constants.PARAM_FLATTEN) is not None:
+            query.flatten_metadata_response()
+
+    def check_meta(self, query, args):
         metadata = args.get(constants.PARAM_METADATA)
         if not metadata:
             return

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -161,14 +161,12 @@ class Query(object):
         distribution = field.distribution
         dataset = distribution.dataset
         catalog = dataset.catalog
-        metadata = json.loads(catalog.metadata)
-        dataset_meta = json.loads(dataset.metadata)
-        distribution_meta = json.loads(distribution.metadata)
-        field_meta = json.loads(field.metadata)
-        distribution_meta['field'] = [field_meta]
-        dataset_meta['distribution'] = [distribution_meta]
-        metadata['dataset'] = [dataset_meta]
-        return metadata
+        return {
+            'catalog': json.loads(catalog.metadata),
+            'dataset': json.loads(dataset.metadata),
+            'distribution': json.loads(distribution.metadata),
+            'field': json.loads(field.metadata)
+        }
 
     def _calculate_data_frequency(self):
         """Devuelve la periodicidad de la o las series pedidas. Si son
@@ -202,21 +200,22 @@ class Query(object):
         # Idea: obtener todos los metadatos y descartar los que no queremos
         meta = self._get_full_metadata(serie_model)
 
-        for meta_field in list(meta):
+        catalog = meta['catalog']
+        for meta_field in list(catalog):
             if meta_field not in constants.CATALOG_SIMPLE_META_FIELDS:
-                meta.pop(meta_field)
+                catalog.pop(meta_field)
 
-        dataset = meta['dataset'][0]  # Dataset de un único elemento
+        dataset = meta['dataset']
         for meta_field in list(dataset):
             if meta_field not in constants.DATASET_SIMPLE_META_FIELDS:
                 dataset.pop(meta_field)
 
-        distribution = dataset['distribution'][0]
+        distribution = meta['distribution']
         for meta_field in list(distribution):
             if meta_field not in constants.DISTRIBUTION_SIMPLE_META_FIELDS:
                 distribution.pop(meta_field)
 
-        field = distribution['field'][0]
+        field = meta['field']
         for meta_field in list(field):
             if meta_field not in constants.FIELD_SIMPLE_META_FIELDS:
                 field.pop(meta_field)

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -101,7 +101,7 @@ class QueryTests(TestCase):
 
         self.query.add_series(self.single_series, self.field)
         self.query.run()
-        index_meta = self.query.get_metadata()[1]
+        index_meta = self.query.get_metadata()[1]['catalog']
         self.assertNotIn('extra_field', index_meta)
         self.assertIn('title', index_meta)
 
@@ -112,9 +112,9 @@ class QueryTests(TestCase):
 
         self.query.add_series(self.single_series, self.field)
         self.query.run()
-        index_meta = self.query.get_metadata()[1]
+        index_meta = self.query.get_metadata()[1]['dataset']
         self.assertNotIn('extra_field', index_meta)
-        self.assertIn('title', index_meta['dataset'][0])
+        self.assertIn('title', index_meta)
 
     def test_simple_metadata_remove_distribution(self):
         dist = self.field.distribution
@@ -123,9 +123,9 @@ class QueryTests(TestCase):
 
         self.query.add_series(self.single_series, self.field)
         self.query.run()
-        index_meta = self.query.get_metadata()[1]
+        index_meta = self.query.get_metadata()[1]['distribution']
         self.assertNotIn('extra_field', index_meta)
-        self.assertIn('title', index_meta['dataset'][0]['distribution'][0])
+        self.assertIn('title', index_meta)
 
     def test_simple_metadata_remove_field(self):
         self.field.metadata = '{"id": "test_title", "extra_field": "extra"}'
@@ -133,6 +133,6 @@ class QueryTests(TestCase):
 
         self.query.add_series(self.single_series, self.field)
         self.query.run()
-        index_meta = self.query.get_metadata()[1]
+        index_meta = self.query.get_metadata()[1]['field']
         self.assertNotIn('extra_field', index_meta)
-        self.assertIn('id', index_meta['dataset'][0]['distribution'][0]['field'][0])
+        self.assertIn('id', index_meta)

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -136,3 +136,67 @@ class QueryTests(TestCase):
         index_meta = self.query.get_metadata()[1]['field']
         self.assertNotIn('extra_field', index_meta)
         self.assertIn('id', index_meta)
+
+    def test_flatten_metadata_response(self):
+        catalog = self.field.distribution.dataset.catalog
+        catalog.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        catalog.save()
+
+        dataset = self.field.distribution.dataset
+        dataset.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        dataset.save()
+
+        dist = self.field.distribution
+        dist.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        dist.save()
+
+        self.field.metadata = '{"id": "test_title", "extra_field": "extra"}'
+        self.field.save()
+
+        self.query.add_series(self.single_series, self.field)
+        self.query.flatten_metadata_response()
+        self.query.run()
+
+        flat_meta = self.query.get_metadata()[1]
+
+        other_query = Query(index=settings.TEST_INDEX)
+        other_query.add_series(self.single_series, self.field)
+        other_query.run()
+        meta = other_query.get_metadata()[1]
+
+        for key in meta:
+            for in_key in meta[key]:
+                self.assertEqual(meta[key][in_key], flat_meta['{}_{}'.format(key, in_key)])
+
+    def test_full_metadata_flat_response(self):
+        catalog = self.field.distribution.dataset.catalog
+        catalog.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        catalog.save()
+
+        dataset = self.field.distribution.dataset
+        dataset.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        dataset.save()
+
+        dist = self.field.distribution
+        dist.metadata = '{"title": "test_title", "extra_field": "extra"}'
+        dist.save()
+
+        self.field.metadata = '{"id": "test_title", "extra_field": "extra"}'
+        self.field.save()
+
+        self.query.add_series(self.single_series, self.field)
+        self.query.set_metadata_config('full')
+        self.query.flatten_metadata_response()
+        self.query.run()
+
+        flat_meta = self.query.get_metadata()[1]
+
+        other_query = Query(index=settings.TEST_INDEX)
+        other_query.add_series(self.single_series, self.field)
+        other_query.set_metadata_config('full')
+        other_query.run()
+        meta = other_query.get_metadata()[1]
+
+        for key in meta:
+            for in_key in meta[key]:
+                self.assertEqual(meta[key][in_key], flat_meta['{}_{}'.format(key, in_key)])


### PR DESCRIPTION
Closes #255

- El campo `meta` de la respuesta del endpoint `/series` se modifica para tener una única jerarquía de objetos JSON en vez de la esctura anidada propia de los `data.json`:

```json
    {
        "catalog": [<catalog_meta>],
        "dataset": [<dataset_meta>],
        "distribution": [<distribution_meta>],
        "field": [<field_meta>],
    }
```
- Se agrega un parámetro `flatten` para que la respuesta devuelva un campo `meta` con un único nivel:

```json
    {
        catalog_meta1: ...,
        catalog_meta2: ...,
        dataset_meta1: ...,
        <nivel>_<meta_key>: <meta_value>
        ...
    }
```