### PR TITLE
Aumento el timeout de export_analytics

### DIFF
--- a/series_tiempo_ar_api/apps/analytics/tasks.py
+++ b/series_tiempo_ar_api/apps/analytics/tasks.py
@@ -20,7 +20,7 @@ def analytics(ids, args_string, ip_address, params, timestamp_milliseconds):
     query.save()
 
 
-@job("default")
+@job("default", timeout=360)
 def export(path=None):
     queryset = Query.objects.all()
     filepath = path or os.path.join(settings.PROTECTED_MEDIA_DIR, settings.ANALYTICS_CSV_FILENAME)


### PR DESCRIPTION
Closes #301 

Los errores eran de **export**, no de import! Los timeouts ocurrían porque escribir un CSV de 5 millones de rows tarda más que 180 segundos. Queda pendiente resolver el problema de fondo de estar escribiendo un CSV de 5 millones de rows.