### PR TITLE
Modifico el import_analytics para poder importar la base de cero

### DIFF
--- a/series_tiempo_ar_api/apps/analytics/importer.py
+++ b/series_tiempo_ar_api/apps/analytics/importer.py
@@ -17,7 +17,7 @@ class AnalyticsImporter:
         # Precálculo
         self.loaded_api_mgmt_ids = set(Query.objects.values_list('api_mgmt_id', flat=True))
 
-    def run(self):
+    def run(self, import_all=False):
         task = AnalyticsImportTask(status=AnalyticsImportTask.RUNNING,
                                    timestamp=timezone.now())
         import_config_model = ImportConfig.get_solo()
@@ -27,16 +27,16 @@ class AnalyticsImporter:
             import_config_model.token
         ))
         try:
-            count = self._run_import()
+            count = self._run_import(import_all)
             task.write_logs("Todo OK. Queries importadas: {}".format(count))
         except Exception as e:
             task.write_logs("Error importando analytics: {}".format(e))
         task.status = task.FINISHED
         task.save()
 
-    def _run_import(self):
+    def _run_import(self, import_all=False):
         last_query = Query.objects.last()
-        if last_query is None:
+        if import_all or last_query is None:
             start_date = None
         else:
             start_date = last_query.timestamp.date()

--- a/series_tiempo_ar_api/apps/analytics/management/commands/import_analytics.py
+++ b/series_tiempo_ar_api/apps/analytics/management/commands/import_analytics.py
@@ -5,5 +5,10 @@ from series_tiempo_ar_api.apps.analytics.tasks import import_last_day_analytics_
 
 
 class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('--all', default=False, action='store_true')
+
     def handle(self, *args, **options):
-        import_last_day_analytics_from_api_mgmt()
+        import_all = options['all']
+        import_last_day_analytics_from_api_mgmt(import_all=import_all)

--- a/series_tiempo_ar_api/apps/analytics/tasks.py
+++ b/series_tiempo_ar_api/apps/analytics/tasks.py
@@ -42,5 +42,5 @@ def export(path=None):
 
 
 @job('default', timeout=1000)
-def import_last_day_analytics_from_api_mgmt(limit=1000, requests_lib=requests):
-    AnalyticsImporter(limit, requests_lib).run()
+def import_last_day_analytics_from_api_mgmt(limit=1000, requests_lib=requests, import_all=False):
+    AnalyticsImporter(limit, requests_lib).run(import_all)

--- a/series_tiempo_ar_api/apps/analytics/tests/import_tests.py
+++ b/series_tiempo_ar_api/apps/analytics/tests/import_tests.py
@@ -25,7 +25,7 @@ class FakeRequests:
         self.responses = responses
         self.index = 0
 
-    def get(self, *args, **kwargs):
+    def get(self, *_, **__):
         response = self.Response(self.responses[self.index])
         self.index += 1
         return response
@@ -65,6 +65,75 @@ class ImportTests(TestCase):
                 ]
             }
         ]))
+        self.assertEqual(Query.objects.count(), 1)
+
+    def test_many_results(self):
+        import_last_day_analytics_from_api_mgmt(requests_lib=FakeRequests([
+            {
+                'next': None,
+                'count': 1,
+                'results': [
+                    {
+                        'ip_address': '127.0.0.1',
+                        'querystring': '',
+                        'start_time': '2018-06-07T05:00:00-03:00',
+                        'id': 1,
+                        'uri': '/series/api/series/',
+                    },
+                    {
+                        'ip_address': '127.0.0.1',
+                        'querystring': '',
+                        'start_time': '2018-06-07T05:00:01-03:00',
+                        'id': 2,
+                        'uri': '/series/api/series/',
+                    }
+                ]
+            }
+        ]))
+        self.assertEqual(Query.objects.count(), 2)
+
+    def test_import_all_flag(self):
+        self.test_many_results()
+
+        # Borro un dato, y me aseguro que se regenera con import_all
+        Query.objects.first().delete()
+        import_last_day_analytics_from_api_mgmt(requests_lib=FakeRequests([
+            {
+                'next': None,
+                'count': 1,
+                'results': [
+                    {
+                        'ip_address': '127.0.0.1',
+                        'querystring': '',
+                        'start_time': '2018-06-07T05:00:00-03:00',
+                        'id': 1,
+                        'uri': '/series/api/series/',
+                    },
+                    {
+                        'ip_address': '127.0.0.1',
+                        'querystring': '',
+                        'start_time': '2018-06-08T05:00:01-03:00',
+                        'id': 2,
+                        'uri': '/series/api/series/',
+                    }
+                ]
+            }
+        ]), import_all=True)
+        self.assertEqual(Query.objects.count(), 2)
+
+    def test_without_import_all_model_is_not_recreated(self):
+        self.test_many_results()
+
+        # Borro un dato. Si no le paso import_all=True, no se va a crear de nuevo
+        Query.objects.all().order_by('-timestamp').last().delete()
+        import_last_day_analytics_from_api_mgmt(requests_lib=FakeRequests([
+            {
+                'next': None,
+                'count': 0,
+                'results': [
+                ]
+            }
+        ]), import_all=False)
         self.assertEqual(Query.objects.count(), 1)
 
     def test_multiple_page_results(self):


### PR DESCRIPTION
Se agrega un parámetro `--all` al mgmt command de import_analytics para traerse y actualizar la base entera desde el primer resultado. 

Closes #309 