### PR TITLE
Hago opcional el parámetro 'q' de /search

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/queries/query.py
+++ b/series_tiempo_ar_api/apps/metadata/queries/query.py
@@ -27,9 +27,6 @@ class FieldSearchQuery(object):
         except ValueError:
             self.append_error(strings.INVALID_PARAMETER.format(constants.PARAM_OFFSET, offset))
 
-        if not self.args.get(constants.PARAM_QUERYSTRING):
-            self.append_error(strings.EMPTY_QUERYSTRING)
-
     def execute(self):
         """Ejecuta la query. Devuelve un diccionario con el siguiente formato
         {
@@ -53,11 +50,14 @@ class FieldSearchQuery(object):
             return self.response
 
         es_client = ElasticInstance.get()
+        search = Field.search(using=es_client)
 
-        querystring = self.args[constants.PARAM_QUERYSTRING]
+        querystring = self.args.get(constants.PARAM_QUERYSTRING)
+        if querystring is not None:
+            search = search.query('match', _all=querystring)
+
         offset = self.args[constants.PARAM_OFFSET]
         limit = self.args[constants.PARAM_LIMIT]
-        search = Field.search(using=es_client).query('match', _all=querystring)
         search = search[offset:limit + offset]
 
         for arg, field in constants.FILTER_ARGS.items():

--- a/series_tiempo_ar_api/apps/metadata/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/query_tests.py
@@ -16,12 +16,12 @@ mock.patch.object = mock.patch.object  # Hack for pylint inspection
 
 class QueryTests(TestCase):
 
-    def test_no_querystring(self):
+    def test_no_querystring_is_valid(self):
         query = FieldSearchQuery(args={})
 
         result = query.execute()
 
-        self.assertTrue(result['errors'])
+        self.assertFalse(result.get('errors'))
 
     def test_bad_limit(self):
         query = FieldSearchQuery(args={'limit': 'invalid'})

--- a/series_tiempo_ar_api/apps/metadata/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/query_tests.py
@@ -19,7 +19,8 @@ class QueryTests(TestCase):
     def test_no_querystring_is_valid(self):
         query = FieldSearchQuery(args={})
 
-        result = query.execute()
+        with mock.patch.object(Search, 'execute', return_value=get_mock_search()):
+            result = query.execute()
 
         self.assertFalse(result.get('errors'))
 


### PR DESCRIPTION
Si no se especifica, devuelve todas los resultados posibles

Closes #313 
