### PR TITLE
Reorganizo el índice de metadatos

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/constants.py
+++ b/series_tiempo_ar_api/apps/metadata/constants.py
@@ -14,3 +14,6 @@ FILTER_ARGS = {
     'dataset_source': 'dataset_source_keyword',
     'catalog_id': 'catalog_id',
 }
+
+
+ANALYZER = 'spanish_asciifold'

--- a/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
@@ -3,29 +3,32 @@ from elasticsearch_dsl import DocType, Keyword, Text, Date, MetaField
 
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+from .index import fields_meta
 
 
 class Field(DocType):
     """ Formato de los docs de metadatos a indexar en ES."""
     title = Keyword()
-    description = Text()
+    description = Text(analyzer=constants.ANALYZER, copy_to='all')
     id = Keyword()
-    dataset_title = Text()
-    dataset_description = Text()
-    dataset_theme = Keyword()
-    units = Keyword()
-    dataset_publisher_name = Keyword()
-    catalog_id = Keyword()
+    dataset_title = Text(analyzer=constants.ANALYZER, copy_to='all')
+    dataset_description = Text(analyzer=constants.ANALYZER, copy_to='all')
+    dataset_theme = Keyword(copy_to='all')
+    units = Keyword(copy_to='all')
+    dataset_publisher_name = Keyword(copy_to='all')
+    catalog_id = Keyword(copy_to='all')
 
     # Guardamos una copia como keyword para poder usar en aggregations
-    dataset_source = Text()
+    dataset_source = Text(analyzer=constants.ANALYZER, copy_to='all')
     dataset_source_keyword = Keyword()
 
     periodicity = Keyword()
     start_date = Date()
     end_date = Date()
 
+    all = Text(analyzer=constants.ANALYZER)
+
     class Meta:
         dynamic = MetaField('strict')
-        index = constants.FIELDS_INDEX
+        index = fields_meta._name
         using = ElasticInstance.get()

--- a/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
@@ -3,7 +3,7 @@ from elasticsearch_dsl import DocType, Keyword, Text, Date, MetaField
 
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
-from .index import fields_meta
+from .index import get_fields_meta_index
 
 
 class Field(DocType):
@@ -30,5 +30,5 @@ class Field(DocType):
 
     class Meta:
         dynamic = MetaField('strict')
-        index = fields_meta._name
+        index = get_fields_meta_index()._name
         using = ElasticInstance.get()

--- a/series_tiempo_ar_api/apps/metadata/indexer/index.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/index.py
@@ -1,0 +1,18 @@
+#! coding: utf-8
+from elasticsearch_dsl import Index, analyzer
+
+from series_tiempo_ar_api.apps.metadata import constants
+from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+
+
+def add_analyzer(index: Index):
+    index.analyzer(
+        analyzer(constants.ANALYZER,
+                 tokenizer='standard',
+                 filter=['lowercase', 'asciifolding'])
+    )
+
+
+fields_meta = Index(constants.FIELDS_INDEX, using=ElasticInstance.get())
+
+add_analyzer(fields_meta)

--- a/series_tiempo_ar_api/apps/metadata/indexer/index.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/index.py
@@ -6,6 +6,11 @@ from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
 
 
 def add_analyzer(index: Index):
+    """Agrega un nuevo analyzer al índice, disponible para ser usado
+    en todos sus fields. El analyzer aplica lower case + ascii fold:
+    quita acentos y uso de ñ, entre otros, para permitir búsqueda de
+    texto en español
+    """
     index.analyzer(
         analyzer(constants.ANALYZER,
                  tokenizer='standard',
@@ -13,6 +18,8 @@ def add_analyzer(index: Index):
     )
 
 
-fields_meta = Index(constants.FIELDS_INDEX, using=ElasticInstance.get())
+def get_fields_meta_index():
+    fields_meta = Index(constants.FIELDS_INDEX, using=ElasticInstance.get())
 
-add_analyzer(fields_meta)
+    add_analyzer(fields_meta)
+    return fields_meta

--- a/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
@@ -9,14 +9,14 @@ from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
 from .doc_types import Field
 from .catalog_meta_indexer import CatalogMetadataIndexer
-from .index import fields_meta
+from .index import get_fields_meta_index
 
 logger = logging.getLogger(__name__)
 
 
 class MetadataIndexer:
 
-    def __init__(self, task, doc_type=Field, index: Index = fields_meta):
+    def __init__(self, task, doc_type=Field, index: Index = get_fields_meta_index()):
         self.task = task
         self.elastic = ElasticInstance.get()
         self.index = index

--- a/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
@@ -3,26 +3,29 @@ import logging
 
 from django_rq import job
 
+from elasticsearch_dsl import Index
 from django_datajsonar.models import Node
-from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Field
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+from .doc_types import Field
 from .catalog_meta_indexer import CatalogMetadataIndexer
+from .index import fields_meta
 
 logger = logging.getLogger(__name__)
 
 
 class MetadataIndexer:
 
-    def __init__(self, task, doc_type=Field):
+    def __init__(self, task, doc_type=Field, index: Index = fields_meta):
         self.task = task
         self.elastic = ElasticInstance.get()
+        self.index = index
         self.doc_type = doc_type
-        self.index = self.doc_type._doc_type.index
 
     def init_index(self):
-        if not self.elastic.indices.exists(self.index):
-            self.doc_type.init(using=self.elastic)
+        if not self.index.exists():
+            self.index.doc_type(self.doc_type)
+            self.index.create()
 
         # Actualizo el mapping por si se agregan nuevos campos
         self.doc_type._doc_type.refresh()

--- a/series_tiempo_ar_api/apps/metadata/queries/query.py
+++ b/series_tiempo_ar_api/apps/metadata/queries/query.py
@@ -57,7 +57,7 @@ class FieldSearchQuery(object):
 
         querystring = self.args.get(constants.PARAM_QUERYSTRING)
         if querystring is not None:
-            search = search.query('match', _all=querystring)
+            search = search.query('match', all=querystring)
 
         offset = self.args[constants.PARAM_OFFSET]
         limit = self.args[constants.PARAM_LIMIT]


### PR DESCRIPTION
Se configura un analyzer para el índice, y se aplica en todos los campos relevantes a una búsqueda.
Se copian todos los campos a uno nuevo, 'all', para reemplazar el uso de _all, deprecado en ES 6.0
En la view de query, se hace la búsqueda por 'all' en vez del deprecado '_all'.

Closes #331 
