### PR TITLE
Aumento el límite de window de ES

### DIFF
--- a/conf/settings/api/api.py
+++ b/conf/settings/api/api.py
@@ -26,9 +26,12 @@ VALID_STATUS_CODES = (
     201
 )
 
+MAX_SERIES_VALUES = 100000
+MAX_LIMIT = 1000
+
 MAX_ALLOWED_VALUES = {
-    'start': 100000,  # tbd
-    'limit': 1000,
+    'start': MAX_SERIES_VALUES - MAX_LIMIT,  # Offset máximo
+    'limit': MAX_LIMIT,  # Tamaño de página
     'ids': 20  # Cantidad máxima de series que se pueden pedir
 }
 

--- a/series_tiempo_ar_api/apps/api/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/view_tests.py
@@ -7,8 +7,6 @@ from django.http import JsonResponse
 from django.test import TestCase, Client
 from django.urls import reverse
 
-from series_tiempo_ar_api.apps.api.tests.helpers import setup_database
-
 SERIES_NAME = settings.TEST_SERIES_NAME.format('month')
 
 
@@ -111,3 +109,10 @@ class ViewTests(TestCase):
 
         for line in reader:
             self.assertTrue(len(line), 2)
+
+    def test_start_over_limit_returns_400(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': SERIES_NAME,
+                                         'start': '999999'})
+
+        self.assertEqual(response.status_code, 400)

--- a/series_tiempo_ar_api/apps/api/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/view_tests.py
@@ -116,3 +116,10 @@ class ViewTests(TestCase):
                                          'start': '999999'})
 
         self.assertEqual(response.status_code, 400)
+
+    def test_start_over_10000_returns_200(self):
+        response = self.client.get(self.endpoint,
+                                   data={'ids': SERIES_NAME,
+                                         'start': '10001'})
+
+        self.assertEqual(response.status_code, 200)

--- a/series_tiempo_ar_api/apps/dump/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/dump/tests/view_tests.py
@@ -26,7 +26,10 @@ class ViewTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super(ViewTests, cls).setUpClass()
-        ElasticInstance.get().indices.create(cls.index, body=INDEX_CREATION_BODY)
+        es_client = ElasticInstance.get()
+        if es_client.indices.exists(cls.index):
+            es_client.indices.delete(cls.index)
+        es_client.indices.create(cls.index, body=INDEX_CREATION_BODY)
 
         cls.catalog_id = 'csv_dump_test_catalog'
         path = os.path.join(samples_dir, 'distribution_daily_periodicity.json')

--- a/series_tiempo_ar_api/libs/indexing/indexer/index.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/index.py
@@ -11,8 +11,7 @@ def tseries_index(name: str) -> Index:
 
     # Fija el límite superior de valores en una respuesta. Si filtramos por serie, sería
     # la cantidad de valores máximas que puede tener una única serie temporal.
-    max_window = settings.MAX_ALLOWED_VALUES['start'] - settings.MAX_ALLOWED_VALUES['limit']
-    index.settings(max_result_window=max_window)
+    index.settings(max_result_window=settings.MAX_SERIES_VALUES)
 
     if not index.exists():
         index.create()

--- a/series_tiempo_ar_api/libs/indexing/indexer/index.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/index.py
@@ -2,8 +2,8 @@
 
 from elasticsearch_dsl import Index
 from django.conf import settings
-from .. import constants
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+from .. import constants
 
 
 def tseries_index(name: str) -> Index:

--- a/series_tiempo_ar_api/libs/indexing/indexer/index.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/index.py
@@ -1,0 +1,31 @@
+#! coding: utf-8
+
+from elasticsearch_dsl import Index
+from django.conf import settings
+from .. import constants
+from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+
+
+def tseries_index(name: str) -> Index:
+    index = Index(name, using=ElasticInstance.get())
+
+    # Fija el límite superior de valores en una respuesta. Si filtramos por serie, sería
+    # la cantidad de valores máximas que puede tener una única serie temporal.
+    max_window = settings.MAX_ALLOWED_VALUES['start'] - settings.MAX_ALLOWED_VALUES['limit']
+    index.settings(max_result_window=max_window)
+
+    if not index.exists():
+        index.create()
+        index.put_mapping(doc_type=settings.TS_DOC_TYPE,
+                          body=constants.MAPPING)
+
+    index.save()
+    # Actualizo el mapping
+    mapping = index.get_mapping(doc_type=settings.TS_DOC_TYPE)
+
+    doc_properties = mapping[name]['mappings'][settings.TS_DOC_TYPE]['properties']
+    if not doc_properties.get('raw_value'):
+        index.put_mapping(doc_type=settings.TS_DOC_TYPE,
+                          body=constants.MAPPING)
+
+    return index


### PR DESCRIPTION
El default es 10000, si se pedía un valor mayor a ese se devolvía un error 500. Se aumenta a 100000. Sabiendo que la gran mayoría de las series actuales (>99.9%) tienen menos de 10000 valores, no debería afectar negativamente la performance de la aplicación.

Además aprovecho para pasar a utilizar `elasticsearch_dsl` para manejar el índice de series de tiempo.

Closes #326 
