### PR TITLE
Fix a tamaño de respuesta mayor al pedido

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/es_query/series.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/series.py
@@ -59,5 +59,5 @@ class Series(object):
 
     def add_pagination(self, start, limit):
         # ☢️☢️☢️
-        es_offset = limit + extra_offset(self.args[constants.PARAM_PERIODICITY])
+        es_offset = start + limit + extra_offset(self.args[constants.PARAM_PERIODICITY])
         self.search = self.search[start:es_offset]

--- a/series_tiempo_ar_api/apps/api/query/pipeline.py
+++ b/series_tiempo_ar_api/apps/api/query/pipeline.py
@@ -111,7 +111,7 @@ class Pagination(BaseOperation):
             return
 
         start = int(start)
-        limit = start + int(limit)
+        limit = int(limit)
         query.add_pagination(start, limit)
 
     def validate_arg(self, arg, min_value=0, name=constants.PARAM_LIMIT):


### PR DESCRIPTION
Closes #354 

Este cambio permite que en otro lado cuando acotamos la cantidad de respuestas por response = response[:limit] ese `limit` sea el pasado por parámetro y no la suma que valía anteriormente