### PR TITLE
Borro series duplicadas antes de indexar

### DIFF
--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -5,6 +5,7 @@ from functools import reduce
 
 import pandas as pd
 from django.conf import settings
+from django_datajsonar.models import Distribution
 from elasticsearch.helpers import parallel_bulk
 from series_tiempo_ar.helpers import freq_iso_to_pandas
 from series_tiempo_ar_api.apps.management import meta_keys
@@ -12,6 +13,7 @@ from series_tiempo_ar_api.apps.management import meta_keys
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
 from series_tiempo_ar_api.libs.indexing import constants
 from series_tiempo_ar_api.libs.indexing import strings
+from series_tiempo_ar_api.libs.indexing.indexer.utils import remove_duplicated_fields
 from .operations import process_column
 from .metadata import update_enhanced_meta
 from .index import tseries_index
@@ -44,6 +46,7 @@ class DistributionIndexer:
             if not success:
                 logger.warning(strings.BULK_REQUEST_ERROR, info)
 
+        remove_duplicated_fields(distribution)
         for field in distribution.field_set.exclude(title='indice_tiempo'):
             field.enhanced_meta.update_or_create(key=meta_keys.AVAILABLE, value='true')
 

--- a/series_tiempo_ar_api/libs/indexing/indexer/utils.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/utils.py
@@ -1,0 +1,13 @@
+from django.db.models import Count
+from django_datajsonar.models import Distribution
+
+
+def remove_duplicated_fields(distribution: Distribution):
+    non_unique_ids = (distribution.field_set
+                      .values_list('identifier', flat=True)
+                      .annotate(identifier_count=Count('identifier'))
+                      .filter(identifier_count__gt=1))
+
+    for identifier in non_unique_ids:
+        fields = distribution.field_set.filter(identifier=identifier).exclude(present=True)
+        fields.first().delete()

--- a/series_tiempo_ar_api/libs/indexing/tests/utils_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/utils_tests.py
@@ -1,0 +1,85 @@
+from faker import Faker
+from django.test import TestCase
+from django_datajsonar.models import Catalog, Dataset, Distribution, Field
+
+from ..indexer.utils import remove_duplicated_fields
+
+fake = Faker()
+
+
+class DuplicatedFieldsTests(TestCase):
+
+    def setUp(self):
+        catalog = Catalog.objects.create()
+        dataset = Dataset.objects.create(catalog=catalog)
+        self.distribution = Distribution.objects.create(dataset=dataset)
+
+    def test_run_no_duplicated_fields(self):
+        Field.objects.create(distribution=self.distribution,
+                             identifier=fake.pystr(),
+                             title="one_title",
+                             present=True)
+
+        remove_duplicated_fields(self.distribution)
+
+        self.assertEqual(self.distribution.field_set.count(), 1)
+
+    def test_run_duplicated_fields(self):
+        identifier = fake.pystr()
+
+        Field.objects.create(distribution=self.distribution,
+                             identifier=identifier,
+                             title="one_title",
+                             present=True)
+        Field.objects.create(distribution=self.distribution,
+                             identifier=identifier,
+                             title="other_title",
+                             present=False)
+
+        remove_duplicated_fields(self.distribution)
+
+        self.assertEqual(self.distribution.field_set.count(), 1)
+
+    def test_run_not_present_removes_only_one(self):
+        identifier = fake.pystr()
+
+        Field.objects.create(distribution=self.distribution,
+                             identifier=identifier,
+                             title="one_title",
+                             present=False)
+        Field.objects.create(distribution=self.distribution,
+                             identifier=identifier,
+                             title="other_title",
+                             present=False)
+
+        remove_duplicated_fields(self.distribution)
+
+        self.assertEqual(self.distribution.field_set.count(), 1)
+
+    def test_run_multiple_single_fields(self):
+        Field.objects.create(distribution=self.distribution,
+                             identifier=fake.pystr(),
+                             title="one_title",
+                             present=True)
+        Field.objects.create(distribution=self.distribution,
+                             identifier=fake.pystr(),
+                             title="other_title",
+                             present=True)
+
+        remove_duplicated_fields(self.distribution)
+
+        self.assertEqual(self.distribution.field_set.count(), 2)
+
+    def test_run_multiple_non_present_fields(self):
+        Field.objects.create(distribution=self.distribution,
+                             identifier=fake.pystr(),
+                             title="one_title",
+                             present=False)
+        Field.objects.create(distribution=self.distribution,
+                             identifier=fake.pystr(),
+                             title="other_title",
+                             present=False)
+
+        remove_duplicated_fields(self.distribution)
+
+        self.assertEqual(self.distribution.field_set.count(), 2)


### PR DESCRIPTION
django_datajsonar no contempla uniqueness de las series de tiempo, y
crea un modelo nuevo si un Field cambia de titulo. Antes
de indexar datos corremos un pequeño filtro que se encargue de borrar
series duplicadas.

Closes #392
