### PR TITLE
Modifico el orden de las hojas de dumps XLSX

### DIFF
--- a/series_tiempo_ar_api/apps/dump/generator/xlsx/generator.py
+++ b/series_tiempo_ar_api/apps/dump/generator/xlsx/generator.py
@@ -39,13 +39,16 @@ class XLSXWriter:
         with self.csv_dump_file.file as f:
             reader = read_file_as_csv(f)
             header_row = next(reader)
-
+            multiple_sheets = self.multiple_sheets[self.csv_dump_file.file_name]
             workbook = self.workbook_class(xlsx,
                                            header_row=header_row,
-                                           split_by_frequency=self.multiple_sheets[self.csv_dump_file.file_name])
+                                           split_by_frequency=multiple_sheets)
 
             for row in reader:
                 workbook.write_row(row)
+
+        if multiple_sheets:
+            workbook.worksheets_objs.sort(key=sort_key)
 
         workbook.close()
 
@@ -61,6 +64,19 @@ class XLSXWriter:
         node = self.csv_dump_file.node or 'global'
         name = self.csv_dump_file.file_name
         return f'{node}-{name}-{self.csv_dump_file.id}.{DumpFile.TYPE_XLSX}'
+
+
+def sort_key(x):
+    values = {
+        'anual': 0,
+        'semestral': 1,
+        'trimestral': 2,
+        'mensual': 3,
+        'diaria': 4
+    }
+
+    freq, sheet = x.name.split('-')
+    return values[freq], int(sheet)
 
 
 def generate(task: GenerateDumpTask, node: str = None, workbook_class=DumpWorkbook):

--- a/series_tiempo_ar_api/apps/dump/generator/xlsx/workbook.py
+++ b/series_tiempo_ar_api/apps/dump/generator/xlsx/workbook.py
@@ -6,6 +6,10 @@ from series_tiempo_ar_api.apps.dump.generator.xlsx.worksheet import DumpWorkshee
 class DumpWorkbook:
     frequency_col_name = 'indice_tiempo_frecuencia'
 
+    @property
+    def worksheets_objs(self):
+        return self.workbook.worksheets_objs
+
     def __init__(self, filename: str, header_row: list, split_by_frequency=False):
         self.workbook = Workbook(filename, {'constant_memory': True})
         self.split_by_frequency = split_by_frequency

--- a/series_tiempo_ar_api/apps/dump/tests/xlsx_generator_tests.py
+++ b/series_tiempo_ar_api/apps/dump/tests/xlsx_generator_tests.py
@@ -64,9 +64,13 @@ class SheetSortTests(TestCase):
 
         sheets.sort(key=sort_key)
 
-        self.assertEqual(sheets[0], self.MockSheet('anual-1'))
-        self.assertEqual(sheets[-1], self.MockSheet('diaria-2'))
-        self.assertEqual(sheets[-2], self.MockSheet('diaria-1'))
+        expected = self.init_sheets(['anual-1',
+                                     'semestral-1',
+                                     'trimestral-1',
+                                     'mensual-1',
+                                     'diaria-1',
+                                     'diaria-2'])
+        self.assertListEqual(sheets, expected)
 
     def test_sort(self):
         sheets = self.init_sheets([

--- a/series_tiempo_ar_api/apps/dump/tests/xlsx_generator_tests.py
+++ b/series_tiempo_ar_api/apps/dump/tests/xlsx_generator_tests.py
@@ -1,10 +1,11 @@
 import os
+from random import shuffle
 
 from django.core.management import call_command
 from django.test import TestCase
 from faker import Faker
 
-from series_tiempo_ar_api.apps.dump.generator.xlsx.generator import generate
+from series_tiempo_ar_api.apps.dump.generator.xlsx.generator import generate, sort_key
 from series_tiempo_ar_api.apps.dump.models import GenerateDumpTask, DumpFile
 from series_tiempo_ar_api.apps.dump.tasks import enqueue_write_xlsx_task
 from series_tiempo_ar_api.utils import index_catalog
@@ -44,3 +45,56 @@ class XLSXGeneratorTests(TestCase):
                          len(DumpFile.FILENAME_CHOICES))
         self.assertEqual(DumpFile.objects.filter(file_type=DumpFile.TYPE_XLSX, node__catalog_id='catalog_two').count(),
                          len(DumpFile.FILENAME_CHOICES))
+
+
+class SheetSortTests(TestCase):
+
+    class MockSheet:
+        def __init__(self, name):
+            self.name = name
+
+        def __eq__(self, other):
+            return self.name == other.name
+
+    def test_sort_common_case(self):
+        sheets = self.init_sheets(
+            ['anual-1', 'trimestral-1', 'mensual-1', 'diaria-1', 'semestral-1', 'diaria-2']
+        )
+        shuffle(sheets)
+
+        sheets.sort(key=sort_key)
+
+        self.assertEqual(sheets[0], self.MockSheet('anual-1'))
+        self.assertEqual(sheets[-1], self.MockSheet('diaria-2'))
+        self.assertEqual(sheets[-2], self.MockSheet('diaria-1'))
+
+    def test_sort(self):
+        sheets = self.init_sheets([
+            'anual-1',
+            'trimestral-1',
+            'mensual-1',
+            'diaria-1',
+            'semestral-1'
+        ])
+
+        shuffle(sheets)
+
+        sheets.sort(key=sort_key)
+        self.assertListEqual(sheets,
+                             self.init_sheets(['anual-1', 'semestral-1', 'trimestral-1', 'mensual-1', 'diaria-1']))
+
+    def test_sort_pages(self):
+        sheets = self.init_sheets([
+            'anual-1',
+            'diaria-1',
+            'diaria-2',
+            'anual-2',
+            'semestral-1'
+        ])
+        shuffle(sheets)
+
+        sheets.sort(key=sort_key)
+        self.assertListEqual(sheets, self.init_sheets(['anual-1', 'anual-2', 'semestral-1', 'diaria-1', 'diaria-2']))
+
+    def init_sheets(self, names):
+        return [self.MockSheet(name) for name in names]


### PR DESCRIPTION
Se ordenan ahora primero por su frecuencia, y luego por su número de
página. Así anual-1 va a venir antes de diaria-1 y diaria-2