### PR TITLE
Endpoint series: Parámetro 'last'

### DIFF
--- a/conf/settings/api/api.py
+++ b/conf/settings/api/api.py
@@ -32,7 +32,8 @@ MAX_LIMIT = 1000
 MAX_ALLOWED_VALUES = {
     'start': MAX_SERIES_VALUES - MAX_LIMIT,  # Offset máximo
     'limit': MAX_LIMIT,  # Tamaño de página
-    'ids': 40  # Cantidad máxima de series que se pueden pedir
+    'ids': 40,  # Cantidad máxima de series que se pueden pedir
+    'last': MAX_LIMIT,
 }
 
 

--- a/series_tiempo_ar_api/apps/api/helpers.py
+++ b/series_tiempo_ar_api/apps/api/helpers.py
@@ -115,3 +115,10 @@ def extra_offset(periodicity):
         'day': 365,
     }
     return offsets.get(periodicity, 0)
+
+
+def validate_positive_int(last: str) -> int:
+    last = int(last)
+    if last < 0:
+        raise ValueError
+    return last

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -138,3 +138,5 @@ IN_MEMORY_AGGS = [
     AGG_MAX,
     AGG_MIN
 ]
+
+PARAM_LAST = 'last'

--- a/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
@@ -24,6 +24,7 @@ class ESQuery(object):
         self.elastic = ElasticInstance()
         self.data = None
         self.count = None
+        self.reverse_results = False
 
         # Parámetros que deben ser guardados y accedidos varias veces
         self.args = {
@@ -126,7 +127,11 @@ class ESQuery(object):
             raise RuntimeError(strings.DATA_NOT_INITIALIZED)
 
         # Devuelvo hasta LIMIT values
-        return self.data[:self.args[constants.PARAM_LIMIT]]
+        data = self.data[:self.args[constants.PARAM_LIMIT]]
+
+        if self.reverse_results:
+            data.reverse()
+        return data
 
     def get_results_count(self) -> int:
         if self.count is None:
@@ -138,3 +143,6 @@ class ESQuery(object):
         """Equivalente a execute_searches + get_results_data"""
         self.execute_searches()
         return self.get_results_data()
+
+    def reverse(self):
+        self.reverse_results = True

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -200,3 +200,6 @@ class Query(object):
 
     def flatten_metadata_response(self):
         self.metadata_flatten = True
+
+    def reverse(self):
+        self.es_query.reverse()

--- a/series_tiempo_ar_api/apps/api/query/strings.py
+++ b/series_tiempo_ar_api/apps/api/query/strings.py
@@ -26,3 +26,5 @@ END_OF_PERIOD_ERROR = u"Agregación End of Period no soportada para series con �
 INVALID_PARAM_LENGTH = u"El parámetro {} debe ser un solo caracter"
 
 DATA_NOT_INITIALIZED = "Data aún no inicializada. Correr .run()"
+
+EXCLUSIVE_PARAMETERS = "El parámetro {} no puede ser utilizado junto a {}"

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/last_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/last_tests.py
@@ -1,0 +1,82 @@
+import iso8601
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.test import TestCase
+from django_datajsonar.models import Field
+
+from series_tiempo_ar_api.apps.api.query.query import Query
+from series_tiempo_ar_api.apps.api.query.pipeline import Last
+from series_tiempo_ar_api.apps.api.tests.helpers import get_series_id
+
+SERIES_NAME = get_series_id('month')
+
+
+class LastTests(TestCase):
+    single_series = SERIES_NAME
+
+    def setUp(self):
+        self.query = Query(index=settings.TEST_INDEX)
+        self.cmd = Last()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.field = Field.objects.get(identifier=cls.single_series)
+        super(cls, LastTests).setUpClass()
+
+    def test_last_cmd(self):
+        self.query.add_series(self.single_series, self.field)
+        self.cmd.run(self.query, {'last': '10'})
+
+        orig_query = Query(index=settings.TEST_INDEX)
+        orig_query.add_series(self.single_series, self.field)
+        orig_query.sort('desc')
+        data = orig_query.run()['data']
+        data.reverse()
+
+        reverse_data = self.query.run()['data']
+
+        self.assertListEqual(data[-10:], reverse_data)
+
+    def test_last_cmd_with_start_date(self):
+        rows = 100
+        self.query.add_series(self.single_series, self.field)
+        self.cmd.run(self.query, {'last': str(rows)})
+
+        orig_query = Query(index=settings.TEST_INDEX)
+        orig_query.add_series(self.single_series, self.field)
+        orig_query.sort('desc')
+        data = orig_query.run()['data']
+        last_date = iso8601.parse_date(data[-1][0])
+
+        start_date = last_date - relativedelta(years=1)
+        self.query.add_filter(start_date=start_date, end_date=None)
+
+        data = self.query.run()['data']
+        self.assertTrue(len(data), 12)
+
+    def test_sort_mutual_exclusion(self):
+        self.cmd.run(self.query, {'last': '10',
+                                  'sort': 'asc'})
+        self.assertTrue(self.cmd.errors)
+
+    def test_start_mutual_exclusion(self):
+        self.cmd.run(self.query, {'last': '10',
+                                  'start': '10'})
+        self.assertTrue(self.cmd.errors)
+
+    def test_limit_mutual_exclusion(self):
+        self.cmd.run(self.query, {'last': '10',
+                                  'limit': '10'})
+        self.assertTrue(self.cmd.errors)
+
+    def test_invalid_last(self):
+        self.cmd.run(self.query, {'last': 'not_a_number'})
+        self.assertTrue(self.cmd.errors)
+
+    def test_last_over_limit(self):
+        self.cmd.run(self.query, {'last': '999999'})
+        self.assertTrue(self.cmd.errors)
+
+    def test_last_negative(self):
+        self.cmd.run(self.query, {'last': '-10'})
+        self.assertTrue(self.cmd.errors)


### PR DESCRIPTION
last=X (número positivo, hasta 1000 por defecto), devuelve los últimos X
resultados de la serie pedida, en orden de fechas ascendiente.