### PR TITLE
Fix a los dumps globales no generándose

### DIFF
--- a/series_tiempo_ar_api/apps/dump/models.py
+++ b/series_tiempo_ar_api/apps/dump/models.py
@@ -129,7 +129,7 @@ class DumpFile(models.Model):
     def get_last_of_type(cls, file_type: str, node: str = None) -> list:
         """Devuelve el último dump generado del formato file_type especificado.
         Si se pasa un parámetro node, devuelve los últimos dumps para ese node.
-        Si no, se devuelvel los últimos dumps globales.
+        Si no, se devuelve los últimos dumps globales.
         """
 
         dumps_qs = cls.objects.filter(node__catalog_id=node)

--- a/series_tiempo_ar_api/apps/dump/models.py
+++ b/series_tiempo_ar_api/apps/dump/models.py
@@ -129,11 +129,10 @@ class DumpFile(models.Model):
     def get_last_of_type(cls, file_type: str, node: str = None) -> list:
         """Devuelve el último dump generado del formato file_type especificado.
         Si se pasa un parámetro node, devuelve los últimos dumps para ese node.
+        Si no, se devuelvel los últimos dumps globales.
         """
 
-        dumps_qs = cls.objects.all()
-        if node:
-            dumps_qs = dumps_qs.filter(node__catalog_id=node)
+        dumps_qs = cls.objects.filter(node__catalog_id=node)
 
         dumps = []
         for dump_name, _ in cls.FILENAME_CHOICES:

--- a/series_tiempo_ar_api/apps/dump/tests/csv_generator_tests.py
+++ b/series_tiempo_ar_api/apps/dump/tests/csv_generator_tests.py
@@ -7,7 +7,7 @@ import zipfile
 
 from django.conf import settings
 from django.core.management import call_command
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
 from django_datajsonar.models import Field, Node, Catalog
 from faker import Faker
 
@@ -223,7 +223,7 @@ class CSVTest(TestCase):
         Node.objects.all().delete()
 
 
-class CSVDumpCommandTests(TransactionTestCase):
+class CSVDumpCommandTests(TestCase):
     fake = Faker()
     index = fake.word()
 

--- a/series_tiempo_ar_api/apps/dump/tests/model_tests.py
+++ b/series_tiempo_ar_api/apps/dump/tests/model_tests.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+from faker import Faker
+
+from django.test import TestCase
+from django_datajsonar.models import Node
+
+from series_tiempo_ar_api.apps.dump.models import DumpFile, GenerateDumpTask
+
+fake = Faker()
+
+
+class DumpFileTests(TestCase):
+
+    def setUp(self):
+        GenerateDumpTask.objects.create()
+        self.init_dumps_for_type(node=None)
+
+        self.first_node = Node.objects.create(catalog_id=fake.pystr(),
+                                              indexable=True,
+                                              catalog_url=fake.pystr())
+        self.init_dumps_for_type(self.first_node)
+        self.second_node = Node.objects.create(catalog_id=fake.pystr(),
+                                               indexable=True,
+                                               catalog_url=fake.pystr())
+        self.init_dumps_for_type(self.second_node)
+
+    def create_dump_for_node(self, node, _type: str = DumpFile.TYPE_CSV, name: str = DumpFile.FILENAME_FULL):
+        DumpFile.objects.create(node=node,
+                                file_type=_type,
+                                file_name=name,
+                                task=GenerateDumpTask.objects.last())
+
+    def init_dumps_for_type(self, node: Optional[Node], _type: str = DumpFile.TYPE_CSV):
+        for name, _ in DumpFile.FILENAME_CHOICES:
+            self.create_dump_for_node(node, _type, name)
+
+    def test_get_global_dumps_node_is_none(self):
+        dumps = DumpFile.get_last_of_type(DumpFile.TYPE_CSV, None)
+
+        for dump in dumps:
+            self.assertTrue(dump.node is None)
+
+    def test_get_catalog_dumps(self):
+        dumps = DumpFile.get_last_of_type(DumpFile.TYPE_CSV, self.first_node.catalog_id)
+        for dump in dumps:
+            self.assertEqual(dump.node.catalog_id, self.first_node.catalog_id)

--- a/series_tiempo_ar_api/libs/indexing/tests/attachment_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/attachment_tests.py
@@ -9,20 +9,24 @@ from django.test import TestCase
 from django.core.management import call_command
 from pydatajson import DataJson
 
-from django_datajsonar.models import Catalog, Dataset, Distribution, Field
+from django_datajsonar.models import Catalog, Dataset, Distribution, Field, ReadDataJsonTask
 from django_datajsonar.models import Node
 from series_tiempo_ar_api.libs.indexing.report import attachments
+from faker import Faker
+
+fake = Faker()
 
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
 
 
 class AttachmentTests(TestCase):
-    catalog_id = 'test_catalog'
+    catalog_id = fake.pystr()
     catalog = os.path.join(SAMPLES_DIR, 'sample_data.json')
 
     @classmethod
     def setUpClass(cls):
         super(AttachmentTests, cls).setUpClass()
+        ReadDataJsonTask.objects.all().delete()
         Node.objects.all().delete()
         Catalog.objects.all().delete()
         cls.node = Node(catalog_id=cls.catalog_id,

--- a/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
@@ -4,7 +4,7 @@ import datetime
 from unittest import skip
 
 import mock
-from django.test import TransactionTestCase
+from django.test import TestCase
 from django_datajsonar.models import Catalog
 from django.core.files import File
 
@@ -15,7 +15,7 @@ SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
 
 
 @skip
-class FieldEnhancedMetaTests(TransactionTestCase):
+class FieldEnhancedMetaTests(TestCase):
     catalog_id = 'test_catalog'
 
     def setUp(self):


### PR DESCRIPTION
Antes: el script de generación de dumps XLSX global agarraba "los últimos dumps csv generados, filtrando por `node=None`" como base. El filtro ese no se estaba aplicando, y devolvía dumps asociados a cualquier nodo, no a ninguno, haciendo que los que realmente buscabamos con `node=None` nunca se procesen.