### PR TITLE
Restructuración del índice de metadatos

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/constants.py
+++ b/series_tiempo_ar_api/apps/metadata/constants.py
@@ -1,6 +1,7 @@
 #! coding: utf-8
 
-FIELDS_INDEX = 'fields_meta'
+METADATA_ALIAS = 'metadata'
+METADATA_DOC_TYPE = 'doc'
 
 PARAM_LIMIT = 'limit'
 PARAM_OFFSET = 'start'

--- a/series_tiempo_ar_api/apps/metadata/indexer/catalog_meta_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/catalog_meta_indexer.py
@@ -1,22 +1,24 @@
 #! coding: utf-8
 import json
+
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import streaming_bulk
 from pydatajson import DataJson
 from django_datajsonar.models import Field, Node, Metadata, ContentType
-from elasticsearch.helpers import streaming_bulk
 
-from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format_es
 from series_tiempo_ar_api.apps.management import meta_keys
+from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
 
 
 class CatalogMetadataIndexer:
 
-    def __init__(self, node: Node, task: IndexMetadataTask, doc_type):
+    def __init__(self, node: Node, task: IndexMetadataTask, index: str):
         self.node = node
         self.task = task
-        self.doc_type = doc_type
-        self.elastic = ElasticInstance.get()
+        self.index_name = index
+        self.elastic: Elasticsearch = ElasticInstance.get()
         self.fields_meta = {}
         self.init_fields_meta_cache()
         try:
@@ -29,11 +31,15 @@ class CatalogMetadataIndexer:
     def index(self):
         if not self.get_available_fields().count():
             self.task.info(self.task, "No hay series para indexar en este catálogo")
-            return
+            return False
 
+        index_ok = False
         for success, info in streaming_bulk(self.elastic, self.generate_actions()):
             if not success:
                 self.task.info(self.task, 'Error indexando: {}'.format(info))
+            else:
+                index_ok = True
+        return index_ok
 
     def generate_actions(self):
         fields = self.get_available_fields()
@@ -50,7 +56,8 @@ class CatalogMetadataIndexer:
 
             field_meta = json.loads(field.metadata)
             dataset = json.loads(field.distribution.dataset.metadata)
-            doc = self.doc_type(
+            doc = self.generate_es_doc(
+                field.identifier,
                 periodicity=periodicity,
                 start_date=start_date,
                 end_date=end_date,
@@ -67,9 +74,7 @@ class CatalogMetadataIndexer:
                 catalog_id=self.node.catalog_id
             )
 
-            doc.meta.id = field.identifier
-            action = doc.to_dict(include_meta=True)
-            yield action
+            yield doc
 
     def get_available_fields(self):
         field_content_type = ContentType.objects.get_for_model(Field)
@@ -100,3 +105,11 @@ class CatalogMetadataIndexer:
             themes[theme['id']] = theme['label']
 
         return themes
+
+    def generate_es_doc(self, doc_id, **kwargs):
+        return {
+            '_id': doc_id,
+            '_index': self.index_name,
+            '_type': constants.METADATA_DOC_TYPE,
+            '_source': kwargs
+        }

--- a/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
@@ -3,10 +3,9 @@ from elasticsearch_dsl import DocType, Keyword, Text, Date, MetaField
 
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
-from .index import get_fields_meta_index
 
 
-class Field(DocType):
+class Metadata(DocType):
     """ Formato de los docs de metadatos a indexar en ES."""
     title = Keyword()
     description = Text(analyzer=constants.ANALYZER, copy_to='all')
@@ -31,5 +30,4 @@ class Field(DocType):
     class Meta:
         dynamic = MetaField('strict')
         doc_type = constants.METADATA_DOC_TYPE
-        index = constants.METADATA_ALIAS
         using = ElasticInstance.get()

--- a/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/doc_types.py
@@ -30,5 +30,6 @@ class Field(DocType):
 
     class Meta:
         dynamic = MetaField('strict')
-        index = constants.FIELDS_INDEX
+        doc_type = constants.METADATA_DOC_TYPE
+        index = constants.METADATA_ALIAS
         using = ElasticInstance.get()

--- a/series_tiempo_ar_api/apps/metadata/indexer/index.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/index.py
@@ -29,7 +29,7 @@ def add_analyzer(index: Index):
 
 
 def get_fields_meta_index():
-    fields_meta = Index(constants.FIELDS_INDEX, using=ElasticInstance.get())
+    fields_meta = Index(constants.METADATA_ALIAS, using=ElasticInstance.get())
 
     add_analyzer(fields_meta)
     return fields_meta

--- a/series_tiempo_ar_api/apps/metadata/indexer/index.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/index.py
@@ -43,4 +43,3 @@ def init_index(index_name):
         index.create()
     Metadata.init(using=elastic_instance, index=index_name)
     return index
-

--- a/series_tiempo_ar_api/apps/metadata/indexer/index.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/index.py
@@ -4,6 +4,7 @@ from elasticsearch_dsl import Index, analyzer, token_filter
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.apps.metadata.models import Synonym
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
+from .doc_types import Metadata
 
 
 def add_analyzer(index: Index):
@@ -28,8 +29,18 @@ def add_analyzer(index: Index):
     )
 
 
-def get_fields_meta_index():
-    fields_meta = Index(constants.METADATA_ALIAS, using=ElasticInstance.get())
+def get_fields_meta_index(index_name):
+    index = init_index(index_name)
 
-    add_analyzer(fields_meta)
-    return fields_meta
+    return index
+
+
+def init_index(index_name):
+    elastic_instance = ElasticInstance.get()
+    index = Index(index_name, using=elastic_instance)
+    add_analyzer(index)
+    if not index.exists():
+        index.create()
+    Metadata.init(using=elastic_instance, index=index_name)
+    return index
+

--- a/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
@@ -1,31 +1,25 @@
 #! coding: utf-8
 import logging
-import random
 
 from django_rq import job
-from django.utils import timezone
 from elasticsearch import Elasticsearch
 
-from elasticsearch_dsl import Index
 from django_datajsonar.models import Node
 
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
+from series_tiempo_ar_api.apps.metadata.utils import get_random_index_name
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
-from .doc_types import Field
 from .catalog_meta_indexer import CatalogMetadataIndexer
-from .index import get_fields_meta_index
 
 logger = logging.getLogger(__name__)
 
 
 class MetadataIndexer:
 
-    def __init__(self, task, doc_type=Field, index: Index = None):
+    def __init__(self, task):
         self.elastic: Elasticsearch = ElasticInstance.get()
         self.task = task
-        self.index = index if index is not None else get_fields_meta_index()
-        self.doc_type = doc_type
 
     def update_alias(self, index_name):
         if not self.elastic.indices.exists_alias(name=constants.METADATA_ALIAS):
@@ -45,25 +39,26 @@ class MetadataIndexer:
         })
 
     def run(self):
-        index = f"metadata-{random.randrange(1000000)}-{int(timezone.now().timestamp())}"
-        index_ok = False
+        index = get_random_index_name()
+        index_created = False
         for node in Node.objects.filter(indexable=True):
             try:
                 IndexMetadataTask.info(self.task,
                                        u'Inicio de la indexación de metadatos de {}'
                                        .format(node.catalog_id))
-                CatalogMetadataIndexer(node, self.task, index).index()
+                index_created = index_created or CatalogMetadataIndexer(node, self.task, index).index()
                 IndexMetadataTask.info(self.task, u'Fin de la indexación de metadatos de {}'
                                        .format(node.catalog_id))
             except Exception as e:
                 IndexMetadataTask.info(self.task,
                                        u'Error en la lectura del catálogo {}: {}'.format(node.catalog_id, e))
 
-        self.index.forcemerge()
-
-        if index_ok:
-            self.index.forcemerge()
+        if index_created:
+            self.elastic.indices.forcemerge(index=index)
             self.update_alias(index)
+        else:
+            if self.elastic.indices.exists(index):
+                self.elastic.indices.delete(index)
 
 
 @job('indexing', timeout=10000)

--- a/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/metadata_indexer.py
@@ -1,11 +1,17 @@
 #! coding: utf-8
 import logging
+import random
 
 from django_rq import job
+from django.utils import timezone
+from elasticsearch import Elasticsearch
 
 from elasticsearch_dsl import Index
 from django_datajsonar.models import Node
+
+from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
+from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
 from .doc_types import Field
 from .catalog_meta_indexer import CatalogMetadataIndexer
 from .index import get_fields_meta_index
@@ -16,35 +22,48 @@ logger = logging.getLogger(__name__)
 class MetadataIndexer:
 
     def __init__(self, task, doc_type=Field, index: Index = None):
+        self.elastic: Elasticsearch = ElasticInstance.get()
         self.task = task
         self.index = index if index is not None else get_fields_meta_index()
         self.doc_type = doc_type
 
-    def setup_index(self):
-        """Borra y regenera el índice entero. Esto es 'safe' porque
-        todos los datos a indexar en este índice están guardados en
-        la base de datos relacional
-        """
-        if not self.index.exists():
-            self.index.doc_type(self.doc_type)
-            self.index.create()
+    def update_alias(self, index_name):
+        if not self.elastic.indices.exists_alias(name=constants.METADATA_ALIAS):
+            self.elastic.indices.put_alias(index_name, constants.METADATA_ALIAS)
+            return
+        indices = self.elastic.indices.get_alias(name=constants.METADATA_ALIAS).keys()
+
+        actions = [
+            {"add": {"index": index_name, "alias": constants.METADATA_ALIAS}},
+        ]
+
+        for old_index in indices:
+            actions.append({"remove_index": {"index": old_index}})
+
+        self.elastic.indices.update_aliases({
+            "actions": actions
+        })
 
     def run(self):
-        self.setup_index()
+        index = f"metadata-{random.randrange(1000000)}-{int(timezone.now().timestamp())}"
+        index_ok = False
         for node in Node.objects.filter(indexable=True):
             try:
                 IndexMetadataTask.info(self.task,
                                        u'Inicio de la indexación de metadatos de {}'
                                        .format(node.catalog_id))
-                CatalogMetadataIndexer(node, self.task, self.doc_type).index()
+                CatalogMetadataIndexer(node, self.task, index).index()
                 IndexMetadataTask.info(self.task, u'Fin de la indexación de metadatos de {}'
                                        .format(node.catalog_id))
-
             except Exception as e:
                 IndexMetadataTask.info(self.task,
                                        u'Error en la lectura del catálogo {}: {}'.format(node.catalog_id, e))
 
         self.index.forcemerge()
+
+        if index_ok:
+            self.index.forcemerge()
+            self.update_alias(index)
 
 
 @job('indexing', timeout=10000)

--- a/series_tiempo_ar_api/apps/metadata/queries/query.py
+++ b/series_tiempo_ar_api/apps/metadata/queries/query.py
@@ -3,7 +3,7 @@ from elasticsearch_dsl import Search
 
 from series_tiempo_ar_api.apps.metadata.utils import resolve_catalog_id_aliases
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
-from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Field
+from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Metadata
 from series_tiempo_ar_api.apps.metadata import strings, constants
 
 
@@ -52,7 +52,7 @@ class FieldSearchQuery(object):
             return self.response
 
         es_client = ElasticInstance.get()
-        search = Field.search(using=es_client)
+        search = Metadata.search(using=es_client, index=constants.METADATA_ALIAS)
 
         querystring = self.args.get(constants.PARAM_QUERYSTRING)
         if querystring is not None:

--- a/series_tiempo_ar_api/apps/metadata/queries/query_terms.py
+++ b/series_tiempo_ar_api/apps/metadata/queries/query_terms.py
@@ -2,7 +2,8 @@
 from django.conf import settings
 from elasticsearch_dsl import A
 
-from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Field
+from series_tiempo_ar_api.apps.metadata import constants
+from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Metadata
 
 
 def query_field_terms(field=None):
@@ -13,7 +14,7 @@ def query_field_terms(field=None):
     if not field:
         raise ValueError(u'Field a buscar inválido')
 
-    search = Field.search()
+    search = Metadata.search(index=constants.METADATA_ALIAS)
 
     agg = A('terms', field=field, size=settings.MAX_DATASET_SOURCES)
     search.aggs.bucket('results', agg)

--- a/series_tiempo_ar_api/apps/metadata/tests/index_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/index_tests.py
@@ -1,15 +1,18 @@
 #! coding: utf8
 
 from django.test import TestCase
+from faker import Faker
+
 from series_tiempo_ar_api.apps.metadata.indexer.index import get_fields_meta_index
 from series_tiempo_ar_api.apps.metadata.models import Synonym
 from series_tiempo_ar_api.apps.metadata import constants
 
 
 class IndexTests(TestCase):
+    index_name = Faker().pystr().lower()
 
     def test_no_synonyms_has_no_filter(self):
-        index = get_fields_meta_index().to_dict()
+        index = get_fields_meta_index(self.index_name).to_dict()
 
         analyzer = index['settings']['analysis']['analyzer'][constants.ANALYZER]
         self.assertNotIn(constants.SYNONYM_FILTER, analyzer['filter'])
@@ -17,7 +20,7 @@ class IndexTests(TestCase):
     def test_add_synonym(self):
         terms = 'test,terms'
         Synonym.objects.create(terms=terms)
-        index = get_fields_meta_index().to_dict()
+        index = get_fields_meta_index(self.index_name).to_dict()
         filters = index['settings']['analysis']['filter'][constants.SYNONYM_FILTER]
         self.assertIn(terms, filters['synonyms'])
 
@@ -26,7 +29,7 @@ class IndexTests(TestCase):
         for term in terms:
             Synonym.objects.create(terms=term)
 
-        index = get_fields_meta_index().to_dict()
+        index = get_fields_meta_index(self.index_name).to_dict()
         filters = index['settings']['analysis']['filter'][constants.SYNONYM_FILTER]
 
         self.assertEqual(len(filters['synonyms']), 3)

--- a/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
@@ -10,7 +10,6 @@ from django_datajsonar.tasks import read_datajson
 from django_datajsonar.models import ReadDataJsonTask, Node, Field as datajsonar_Field
 
 from series_tiempo_ar_api.apps.metadata.indexer.catalog_meta_indexer import CatalogMetadataIndexer
-from series_tiempo_ar_api.apps.metadata.indexer.doc_types import Field
 from series_tiempo_ar_api.apps.metadata.indexer.index import add_analyzer
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
 from series_tiempo_ar_api.libs.indexing.elastic import ElasticInstance
@@ -24,10 +23,6 @@ add_analyzer(fake_index)
 
 
 class IndexerTests(TestCase):
-
-    class FakeField(Field):
-        class Meta:
-            index = fake_index._name
 
     def setUp(self):
         self.elastic = ElasticInstance.get()

--- a/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import os
 
 import faker
-from elasticsearch_dsl import Index
+from elasticsearch_dsl import Index, Search
 from django.test import TestCase
 from django_datajsonar.tasks import read_datajson
 from django_datajsonar.models import ReadDataJsonTask, Node, Field as datajsonar_Field
@@ -33,27 +33,23 @@ class IndexerTests(TestCase):
         self.elastic = ElasticInstance.get()
         self.task = ReadDataJsonTask.objects.create()
         self.meta_task = IndexMetadataTask.objects.create()
-        fake_index.doc_type(self.FakeField)
-        fake_index.create()
-        self.FakeField.init(using=self.elastic)
 
     def test_index(self):
-        self._index(catalog_id='test_catalog', catalog_url='single_distribution.json')
-        search = self.FakeField.search(
+        index_ok = self._index(catalog_id='test_catalog', catalog_url='single_distribution.json')
+        search = Search(
+            index=fake_index._name,
             using=self.elastic
         ).filter('term',
                  catalog_id='test_catalog')
-
+        self.assertTrue(index_ok)
         self.assertTrue(search.execute())
 
     def test_index_unavailable_fields(self):
-        self._index(catalog_id='test_catalog', catalog_url='single_distribution.json', set_availables=False)
-        search = self.FakeField.search(
-            using=self.elastic
-        ).filter('term',
-                 catalog_id='test_catalog')
+        index_ok = self._index(catalog_id='test_catalog',
+                               catalog_url='single_distribution.json',
+                               set_availables=False)
 
-        self.assertFalse(search.execute())
+        self.assertFalse(index_ok)
 
     def _index(self, catalog_id, catalog_url, set_availables=True):
         node = Node.objects.create(
@@ -67,8 +63,11 @@ class IndexerTests(TestCase):
             for field in datajsonar_Field.objects.all():
                 field.enhanced_meta.create(key=meta_keys.AVAILABLE, value='true')
 
-        CatalogMetadataIndexer(node, self.meta_task, self.FakeField).index()
-        self.elastic.indices.forcemerge()
+        index_ok = CatalogMetadataIndexer(node, self.meta_task, fake_index._name).index()
+        if index_ok:
+            self.elastic.indices.forcemerge()
+        return index_ok
 
     def tearDown(self):
-        fake_index.delete()
+        if fake_index.exists():
+            fake_index.delete()

--- a/series_tiempo_ar_api/apps/metadata/utils.py
+++ b/series_tiempo_ar_api/apps/metadata/utils.py
@@ -28,5 +28,5 @@ def resolve_catalog_id_aliases(aliases: Sequence[str]) -> List[str]:
 def delete_metadata(fields: list):
     es_instance = ElasticInstance.get()
 
-    search = Search(using=es_instance, index=constants.FIELDS_INDEX)
+    search = Search(using=es_instance, index=constants.METADATA_ALIAS)
     return search.filter('terms', id=[field.identifier for field in fields]).delete()

--- a/series_tiempo_ar_api/apps/metadata/utils.py
+++ b/series_tiempo_ar_api/apps/metadata/utils.py
@@ -1,7 +1,9 @@
 #! coding: utf-8
+import random
 from typing import Sequence, List
 
 from django.db.models import QuerySet
+from django.utils import timezone
 from elasticsearch_dsl import Search, Q
 from django_datajsonar.models import Field
 from series_tiempo_ar_api.apps.metadata import constants
@@ -30,3 +32,7 @@ def delete_metadata(fields: list):
 
     search = Search(using=es_instance, index=constants.METADATA_ALIAS)
     return search.filter('terms', id=[field.identifier for field in fields]).delete()
+
+
+def get_random_index_name():
+    return f"metadata-{random.randrange(1000000)}-{int(timezone.now().timestamp())}"


### PR DESCRIPTION
Se pasa de un índice (de Elasticsearch) único de metadatos a generar un índice por corrida de la rutina de indexación de metadatos, y rotar un alias que apunta siempre al índice más reciente. Tiene la intención de solucionar la inconsistencia en la búsqueda de series y los resultados de datos: actualmente aparecen series de tiempo en los resultados de búsquedas que no están indexadas correctamente. Al generarse un índice nuevo en cada corrida, los resultados siempre devolverán series que estamos seguros que existen al momento de la corrida.