### PR TITLE
Agrego método para reindexar distribuciones

### DIFF
--- a/series_tiempo_ar_api/libs/indexing/tests/samples/single_data_value_changed.csv
+++ b/series_tiempo_ar_api/libs/indexing/tests/samples/single_data_value_changed.csv
@@ -1,0 +1,3 @@
+indice_tiempo,ipc_2016_nivel_general
+2018-05-01,1
+2018-06-01,21


### PR DESCRIPTION
Se define la reindexación como el borrado de todas las series
*presentes* de la distribución de Elasticsearch, y su posterior
reindexación. La intención es resolver casos en donde el publicador de
los datos cargó valores incorrectos de una serie de tiempo, que luego
fueron borrados de la fuente, pero que siguen persistiendo en nuestro
índice.