### PR TITLE
Optimizacion de DB en dumps CSV

### DIFF
--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/pagination_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/pagination_tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django_datajsonar.models import Field
 from series_tiempo_ar_api.apps.api.query.pipeline import Pagination
 from series_tiempo_ar_api.apps.api.query.query import Query
-from ..helpers import get_series_id
+from ..helpers import get_series_id, setup_database
 
 SERIES_NAME = get_series_id('month')
 

--- a/series_tiempo_ar_api/apps/dump/generator/dump_csv_writer.py
+++ b/series_tiempo_ar_api/apps/dump/generator/dump_csv_writer.py
@@ -51,11 +51,11 @@ class CsvDumpWriter:
     def write_distribution(self, distribution: Distribution, writer: csv.writer):
         # noinspection PyBroadException
         try:
-            df = read_distribution_csv(distribution)
             fields = distribution.field_set.all()
             fields = {field.title: field.identifier for field in fields}
-
             periodicity = meta_keys.get(distribution, meta_keys.PERIODICITY)
+
+            df = read_distribution_csv(distribution)
             df.apply(self.write_serie, args=(periodicity, fields, writer))
         except Exception as e:
             msg = f'[{self.tag} Error en la distribución {distribution.identifier}: {e.__class__}: {e}'

--- a/series_tiempo_ar_api/apps/dump/generator/metadata.py
+++ b/series_tiempo_ar_api/apps/dump/generator/metadata.py
@@ -32,20 +32,19 @@ class MetadataCsvGenerator(AbstractDumpGenerator):
             field_data['dataset'].identifier,
             field_data['distribution'].identifier,
             field,
-            meta_keys.get(field_data['distribution'], meta_keys.PERIODICITY)
+            field_data[meta_keys.PERIODICITY],
         )
 
     def generate_row(self, serie_name, values):
         dataset = values['dataset']
         distribution = values['distribution']
-        serie = values['serie']
 
         return {
             constants.CATALOG_ID: dataset.catalog.identifier,
             constants.DATASET_ID: dataset.identifier,
             constants.DISTRIBUTION_ID: distribution.identifier,
             constants.SERIE_ID: serie_name,
-            constants.TIME_INDEX_FREQUENCY: meta_keys.get(distribution, meta_keys.PERIODICITY),
+            constants.TIME_INDEX_FREQUENCY: values[meta_keys.PERIODICITY],
             constants.SERIES_TITLE: values[constants.SERIES_TITLE],
             constants.SERIES_UNITS: values[constants.SERIES_UNITS],
             constants.SERIES_DESCRIPTION: values[constants.SERIES_DESCRIPTION],
@@ -57,12 +56,12 @@ class MetadataCsvGenerator(AbstractDumpGenerator):
             constants.DATASET_TITLE: values[constants.DATASET_TITLE],
             constants.DATASET_DESCRIPTION: values[constants.DATASET_DESCRIPTION],
             constants.DATASET_THEME: values[constants.DATASET_THEME],
-            constants.SERIES_INDEX_START: meta_keys.get(serie, meta_keys.INDEX_START),
-            constants.SERIES_INDEX_END: meta_keys.get(serie, meta_keys.INDEX_END),
-            constants.SERIES_VALUES_AMT: meta_keys.get(serie, meta_keys.INDEX_SIZE),
-            constants.SERIES_DAYS_SINCE_LAST_UPDATE: meta_keys.get(serie, meta_keys.DAYS_SINCE_LAST_UPDATE),
-            constants.SERIES_IS_UPDATED: meta_keys.get(serie, meta_keys.IS_UPDATED),
-            constants.SERIES_LAST_VALUE: meta_keys.get(serie, meta_keys.LAST_VALUE),
-            constants.SERIES_SECOND_LAST_VALUE: meta_keys.get(serie, meta_keys.SECOND_TO_LAST_VALUE),
-            constants.SERIES_PCT_CHANGE: meta_keys.get(serie, meta_keys.LAST_PCT_CHANGE),
+            constants.SERIES_INDEX_START: values['metadata'].get(meta_keys.INDEX_START),
+            constants.SERIES_INDEX_END: values['metadata'].get(meta_keys.INDEX_END),
+            constants.SERIES_VALUES_AMT: values['metadata'].get(meta_keys.INDEX_SIZE),
+            constants.SERIES_DAYS_SINCE_LAST_UPDATE: values['metadata'].get(meta_keys.DAYS_SINCE_LAST_UPDATE),
+            constants.SERIES_IS_UPDATED: values['metadata'].get(meta_keys.IS_UPDATED),
+            constants.SERIES_LAST_VALUE: values['metadata'].get(meta_keys.LAST_VALUE),
+            constants.SERIES_SECOND_LAST_VALUE: values['metadata'].get(meta_keys.SECOND_TO_LAST_VALUE),
+            constants.SERIES_PCT_CHANGE: values['metadata'].get(meta_keys.LAST_PCT_CHANGE),
         }

--- a/series_tiempo_ar_api/apps/dump/generator/sources.py
+++ b/series_tiempo_ar_api/apps/dump/generator/sources.py
@@ -18,7 +18,6 @@ class SourcesCsvGenerator(AbstractDumpGenerator):
 
         for field in filter(lambda x: self.fields[x]['dataset_fuente'], self.fields):
             source = self.fields[field]['dataset_fuente']
-            field_model: Field = self.fields[field]['serie']
 
             if source not in sources:
                 sources[source] = {
@@ -30,7 +29,7 @@ class SourcesCsvGenerator(AbstractDumpGenerator):
                 }
 
             sources[source][constants.SOURCE_SERIES_AMT] += 1
-            index_start = meta_keys.get(field_model, meta_keys.INDEX_START)
+            index_start = self.fields[field]['metadata'].get(meta_keys.INDEX_START)
 
             # ☢☢☢
             if index_start:
@@ -39,14 +38,14 @@ class SourcesCsvGenerator(AbstractDumpGenerator):
                 if first_index is None or first_index > index_start:
                     sources[source][constants.SOURCE_FIRST_INDEX] = index_start
 
-            index_end = meta_keys.get(field_model, meta_keys.INDEX_END)
+            index_end = self.fields[field]['metadata'].get(meta_keys.INDEX_END)
             if index_end:
                 index_end = iso8601.parse_date(index_end).date()
                 last_index = sources[source][constants.SOURCE_LAST_INDEX]
                 if last_index is None or last_index < index_end:
                     sources[source][constants.SOURCE_LAST_INDEX] = index_end
 
-            index_size = meta_keys.get(field_model, meta_keys.INDEX_SIZE) or 0
+            index_size = self.fields[field]['metadata'].get(meta_keys.INDEX_SIZE) or 0
 
             if index_size:
                 index_size = int(index_size)


### PR DESCRIPTION
Hace una única lectura grande a la base de datos para metadatos
enriquecidos como paso previo, y maneja el resto en memoria.

Antes se hacía 1 lectura a la base de datos por cada valor de metadato
enriquecido a leer, varios de ellos se leían (mucho) más de una vez. Al
leerlos todos de una en el método init_data() se logra una mejora
considerable de performance (~30m en 1 core vs varias horas en
paralelo), solo teniendo una penalidad de memoria de algunos cientos de
mb, el proceso entero en su totalidad consume 400-500mb, rango manejable
por los servidores.