### PR TITLE
Bugfix: series sin valores cuando se piden de a más de una

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
@@ -74,12 +74,15 @@ class ESQuery(object):
                                   args=self.args,
                                   collapse_agg=collapse_agg))
 
-    def add_pagination(self, start, limit):
+    def add_pagination(self, start, limit, start_dates=None):
+        if start_dates is None:
+            start_dates = {}
+
         if not self.series:
             raise QueryError(strings.EMPTY_QUERY_ERROR)
 
         for serie in self.series:
-            serie.add_pagination(start, limit)
+            serie.add_pagination(start, limit, request_start_dates=start_dates)
 
         # Guardo estos parámetros, necesarios en el evento de hacer un collapse
         self.args[constants.PARAM_START] = start

--- a/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/es_query.py
@@ -24,6 +24,7 @@ class ESQuery(object):
         self.elastic = ElasticInstance()
         self.data = None
         self.count = None
+        self.start_dates = None
         self.reverse_results = False
 
         # Parámetros que deben ser guardados y accedidos varias veces
@@ -66,27 +67,30 @@ class ESQuery(object):
 
     def add_collapse(self, interval):
         self.args[constants.PARAM_PERIODICITY] = interval
+        for serie in self.series:
+            serie.periodicity = interval
 
     def _init_series(self, series_id, rep_mode, collapse_agg):
         self.series.append(Series(series_id=series_id,
                                   index=self.index,
                                   rep_mode=rep_mode,
-                                  args=self.args,
+                                  periodicity=self.args[constants.PARAM_PERIODICITY],
                                   collapse_agg=collapse_agg))
 
     def add_pagination(self, start, limit, start_dates=None):
-        if start_dates is None:
-            start_dates = {}
-
         if not self.series:
             raise QueryError(strings.EMPTY_QUERY_ERROR)
 
-        for serie in self.series:
-            serie.add_pagination(start, limit, request_start_dates=start_dates)
-
-        # Guardo estos parámetros, necesarios en el evento de hacer un collapse
+        # Aplicamos paginación luego, por ahora guardamos los parámetros
         self.args[constants.PARAM_START] = start
         self.args[constants.PARAM_LIMIT] = limit
+        self.start_dates = start_dates or {}
+
+    def setup_series_pagination(self):
+        for serie in self.series:
+            serie.add_pagination(self.args[constants.PARAM_START],
+                                 self.args[constants.PARAM_LIMIT],
+                                 request_start_dates=self.start_dates)
 
     def add_filter(self, start=None, end=None):
         if not self.series:
@@ -117,6 +121,7 @@ class ESQuery(object):
 
         for serie in self.series:
             serie.add_collapse(self.args[constants.PARAM_PERIODICITY])
+            self.setup_series_pagination()
             multi_search = multi_search.add(serie.search)
 
         responses = multi_search.execute()

--- a/series_tiempo_ar_api/apps/api/query/es_query/periods_between.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/periods_between.py
@@ -1,12 +1,12 @@
 from dateutil.relativedelta import relativedelta
 
 
-def days_betwen(first_date, second_date):
+def days_between(first_date, second_date):
     return (first_date - second_date).days
 
 
 def weeks_between(first_date, second_date):
-    return round((first_date - second_date).days / 7)
+    return round(days_between(first_date, second_date) / 7)
 
 
 def months_between(first_date, second_date):
@@ -18,34 +18,27 @@ def months_between(first_date, second_date):
 
 
 def quarters_between(first_date, second_date):
-    quarter_months = (1, 4, 7, 10)
-    result = False
-    if first_date.month not in quarter_months or (first_date.month in quarter_months and first_date.day != 1):
-        result = True
+    period_start_extra = 0 if is_period_start(first_date, (1, 4, 7, 10)) else 1
     delta = relativedelta(first_date, second_date)
-    return delta.months / 3 + 4 * delta.years + result
+    return delta.months / 3 + 4 * delta.years + period_start_extra
 
 
 def semesters_between(first_date, second_date):
-    semester_months = (1, 7)
-    result = False
-    if first_date.month not in semester_months or (first_date.month in semester_months and first_date.day != 1):
-        result = True
+    period_start_extra = 0 if is_period_start(first_date, (1, 7)) else 1
     delta = relativedelta(first_date, second_date)
-    return delta.months / 6 + 2 * delta.years + result
+    return delta.months / 6 + 2 * delta.years + period_start_extra
 
 
 def years_between(first_date, second_date):
-    if first_date.month != 1 or (first_date.month == 1 and first_date.day != 1):
-        first_date += relativedelta(years=1)
+    period_start_extra = 0 if is_period_start(first_date, (1, )) else 1
     delta = relativedelta(first_date, second_date)
 
-    return delta.years
+    return delta.years + period_start_extra
 
 
 def periods_between(first_date, second_date, periodicity):
     dispatcher = {
-        'day': days_betwen,
+        'day': days_between,
         'week': weeks_between,
         'month': months_between,
         'quarter': quarters_between,
@@ -54,3 +47,17 @@ def periods_between(first_date, second_date, periodicity):
     }
 
     return dispatcher[periodicity](first_date, second_date)
+
+
+def is_period_start(date, period_start_months):
+    """Se considera una fecha como comienzo de un período si su día es 1, y su mes es
+    igual al de un período. Para mensual son todos los meses válidos, para trimestral,
+    Enero, Abril, Julio, Octubre, para semestral Enero y Julio, para anual, sólo Enero
+    """
+    if date.month not in period_start_months:
+        return False
+
+    if date.day != 1:
+        return False
+
+    return True

--- a/series_tiempo_ar_api/apps/api/query/es_query/periods_between.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/periods_between.py
@@ -1,0 +1,56 @@
+from dateutil.relativedelta import relativedelta
+
+
+def days_betwen(first_date, second_date):
+    return (first_date - second_date).days
+
+
+def weeks_between(first_date, second_date):
+    return round((first_date - second_date).days / 7)
+
+
+def months_between(first_date, second_date):
+    if first_date.day != 1:
+        first_date += relativedelta(months=1)
+
+    delta = relativedelta(first_date, second_date)
+    return delta.months + 12 * delta.years
+
+
+def quarters_between(first_date, second_date):
+    quarter_months = (1, 4, 7, 10)
+    result = False
+    if first_date.month not in quarter_months or (first_date.month in quarter_months and first_date.day != 1):
+        result = True
+    delta = relativedelta(first_date, second_date)
+    return delta.months / 3 + 4 * delta.years + result
+
+
+def semesters_between(first_date, second_date):
+    semester_months = (1, 7)
+    result = False
+    if first_date.month not in semester_months or (first_date.month in semester_months and first_date.day != 1):
+        result = True
+    delta = relativedelta(first_date, second_date)
+    return delta.months / 6 + 2 * delta.years + result
+
+
+def years_between(first_date, second_date):
+    if first_date.month != 1 or (first_date.month == 1 and first_date.day != 1):
+        first_date += relativedelta(years=1)
+    delta = relativedelta(first_date, second_date)
+
+    return delta.years
+
+
+def periods_between(first_date, second_date, periodicity):
+    dispatcher = {
+        'day': days_betwen,
+        'week': weeks_between,
+        'month': months_between,
+        'quarter': quarters_between,
+        'semester': semesters_between,
+        'year': years_between,
+    }
+
+    return dispatcher[periodicity](first_date, second_date)

--- a/series_tiempo_ar_api/apps/api/query/es_query/series.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/series.py
@@ -59,5 +59,8 @@ class Series(object):
 
     def add_pagination(self, start, limit):
         # ☢️☢️☢️
-        es_offset = start + limit + extra_offset(self.args[constants.PARAM_PERIODICITY])
+        es_offset = start + limit
+        if self.rep_mode != constants.API_DEFAULT_VALUES[constants.PARAM_REP_MODE]:
+            es_offset += extra_offset(self.args[constants.PARAM_PERIODICITY])
+
         self.search = self.search[start:es_offset]

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from django.conf import settings
 from django_datajsonar.models import Catalog, Dataset, Distribution, Field
+from iso8601 import iso8601
 
 from series_tiempo_ar_api.apps.api.exceptions import CollapseError
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
@@ -47,7 +48,9 @@ class Query(object):
         return self.es_query.get_series_ids()
 
     def add_pagination(self, start, limit):
-        return self.es_query.add_pagination(start, limit)
+        start_dates = {serie.identifier: meta_keys.get(serie, meta_keys.INDEX_START) for serie in self.series_models}
+        start_dates = {k: iso8601.parse_date(v) if v is not None else None for k, v in start_dates.items()}
+        return self.es_query.add_pagination(start, limit, start_dates=start_dates)
 
     def add_filter(self, start_date, end_date):
         return self.es_query.add_filter(start_date, end_date)

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
@@ -51,13 +51,16 @@ class IdsTest(TestCase):
         self.query.sort('asc')
         data = self.query.run()['data']
 
-        other_query = Query(index=settings.TEST_INDEX)
-        self.cmd.run(other_query, {'ids': self.single_series,
-                                   'representation_mode': 'change'})
-        other_query.sort('asc')
-        other_data = other_query.run()['data']
+        change_query = Query(index=settings.TEST_INDEX)
+        self.cmd.run(change_query, {'ids': self.single_series,
+                                    'representation_mode': 'change'})
 
-        for index, row in enumerate(other_data):
+        change_query.sort('asc')
+        # Un valor menos que la query original, 99 variaciones para 100 valores
+        change_query.add_pagination(start=0, limit=99)
+        change_data = change_query.run()['data']
+
+        for index, row in enumerate(change_data):
             change = data[index + 1][1] - data[index][1]
             # La resta anterior trae pérdida de precisión si los números de 'data' son grandes
             self.assertAlmostEqual(row[1], change, places=5)

--- a/series_tiempo_ar_api/apps/api/tests/series_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_tests.py
@@ -1,0 +1,144 @@
+from datetime import datetime
+
+from dateutil.relativedelta import relativedelta
+from django.test import TestCase
+
+from series_tiempo_ar_api.apps.api.query import constants
+from series_tiempo_ar_api.apps.api.query.es_query.series import Series
+from faker import Faker
+
+
+class SeriesStartOffsetTests(TestCase):
+
+    def setUp(self):
+        self.faker = Faker()
+
+    def get_serie(self, periodicity, rep_mode=None):
+        fake_index = self.faker.pystr().lower()
+        serie_id = self.faker.pystr()
+        rep_mode = rep_mode or constants.API_DEFAULT_VALUES[constants.PARAM_REP_MODE]
+        return Series(index=fake_index,
+                      series_id=serie_id,
+                      rep_mode=rep_mode,
+                      periodicity=periodicity)
+
+    def test_series_id_same_start(self):
+        one_serie = self.get_serie('month')
+        other_serie = self.get_serie('month')
+
+        start_date = datetime(2016, 1, 1)
+        start = one_serie.get_es_start({one_serie.series_id: start_date, other_serie.series_id: start_date}, 0)
+
+        self.assertEqual(start, 0)
+
+    def test_series_id_one_month_earlier_start(self):
+        one_serie = self.get_serie('month')
+        other_serie = self.get_serie('month')
+
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(months=1)
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 1)
+        other_start = other_serie.get_es_start(start_dates, 1)
+        self.assertEqual(start, 1)
+        self.assertEqual(other_start, 0)
+
+    def test_series_with_collapse(self):
+        one_serie = self.get_serie('month')
+        other_serie = self.get_serie('month')
+
+        one_serie.add_collapse('year')
+        other_serie.add_collapse('year')
+
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(months=1)
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 1)
+        other_start = other_serie.get_es_start(start_dates, 1)
+        self.assertEqual(start, 1)
+        self.assertEqual(other_start, 0)
+
+    def test_series_different_periodicity(self):
+        one_serie = self.get_serie('year')
+        other_serie = self.get_serie('month')
+
+        other_serie.add_collapse('year')
+
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(months=1)
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 1)
+        other_start = other_serie.get_es_start(start_dates, 1)
+        self.assertEqual(start, 1)
+        self.assertEqual(other_start, 0)
+
+    def test_series_start_many_years_delay(self):
+        one_serie = self.get_serie('year')
+        other_serie = self.get_serie('year')
+
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(years=100)
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 50)
+        other_start = other_serie.get_es_start(start_dates, 50)
+        self.assertEqual(start, 50)
+        self.assertEqual(other_start, 0)
+
+    def test_series_day_and_month_periodicity(self):
+        one_serie = self.get_serie('month')
+        other_serie = self.get_serie('day')
+
+        other_serie.add_collapse('month')
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(days=1)
+
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 50)
+        other_start = other_serie.get_es_start(start_dates, 50)
+
+        self.assertEqual(start, 50)
+        self.assertEqual(other_start, 49)
+
+    def test_series_day_and_quarter_periodicity(self):
+        one_serie = self.get_serie('quarter')
+        other_serie = self.get_serie('day')
+
+        other_serie.add_collapse('quarter')
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(days=1)
+
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 50)
+        other_start = other_serie.get_es_start(start_dates, 50)
+
+        self.assertEqual(start, 50)
+        self.assertEqual(other_start, 49)
+
+    def test_series_day_and_semester_periodicity(self):
+        one_serie = self.get_serie('semester')
+        other_serie = self.get_serie('day')
+
+        other_serie.add_collapse('semester')
+        one_start_date = datetime(2016, 1, 1)
+        other_start_date = one_start_date + relativedelta(days=1)
+
+        start_dates = {one_serie.series_id: one_start_date,
+                       other_serie.series_id: other_start_date}
+
+        start = one_serie.get_es_start(start_dates, 50)
+        other_start = other_serie.get_es_start(start_dates, 50)
+
+        self.assertEqual(start, 50)
+        self.assertEqual(other_start, 49)

--- a/series_tiempo_ar_api/apps/api/tests/series_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_tests.py
@@ -13,132 +13,132 @@ class SeriesStartOffsetTests(TestCase):
     def setUp(self):
         self.faker = Faker()
 
-    def get_serie(self, periodicity, rep_mode=None):
+    def get_series(self, periodicity, rep_mode=None):
         fake_index = self.faker.pystr().lower()
-        serie_id = self.faker.pystr()
+        series_id = self.faker.pystr()
         rep_mode = rep_mode or constants.API_DEFAULT_VALUES[constants.PARAM_REP_MODE]
         return Series(index=fake_index,
-                      series_id=serie_id,
+                      series_id=series_id,
                       rep_mode=rep_mode,
                       periodicity=periodicity)
 
     def test_series_id_same_start(self):
-        one_serie = self.get_serie('month')
-        other_serie = self.get_serie('month')
+        one_series = self.get_series('month')
+        other_series = self.get_series('month')
 
         start_date = datetime(2016, 1, 1)
-        start = one_serie.get_es_start({one_serie.series_id: start_date, other_serie.series_id: start_date}, 0)
+        start = one_series.get_es_start({one_series.series_id: start_date, other_series.series_id: start_date}, 0)
 
         self.assertEqual(start, 0)
 
     def test_series_id_one_month_earlier_start(self):
-        one_serie = self.get_serie('month')
-        other_serie = self.get_serie('month')
+        one_series = self.get_series('month')
+        other_series = self.get_series('month')
 
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(months=1)
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 1)
-        other_start = other_serie.get_es_start(start_dates, 1)
+        start = one_series.get_es_start(start_dates, 1)
+        other_start = other_series.get_es_start(start_dates, 1)
         self.assertEqual(start, 1)
         self.assertEqual(other_start, 0)
 
     def test_series_with_collapse(self):
-        one_serie = self.get_serie('month')
-        other_serie = self.get_serie('month')
+        one_series = self.get_series('month')
+        other_series = self.get_series('month')
 
-        one_serie.add_collapse('year')
-        other_serie.add_collapse('year')
+        one_series.add_collapse('year')
+        other_series.add_collapse('year')
 
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(months=1)
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 1)
-        other_start = other_serie.get_es_start(start_dates, 1)
+        start = one_series.get_es_start(start_dates, 1)
+        other_start = other_series.get_es_start(start_dates, 1)
         self.assertEqual(start, 1)
         self.assertEqual(other_start, 0)
 
     def test_series_different_periodicity(self):
-        one_serie = self.get_serie('year')
-        other_serie = self.get_serie('month')
+        one_series = self.get_series('year')
+        other_series = self.get_series('month')
 
-        other_serie.add_collapse('year')
+        other_series.add_collapse('year')
 
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(months=1)
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 1)
-        other_start = other_serie.get_es_start(start_dates, 1)
+        start = one_series.get_es_start(start_dates, 1)
+        other_start = other_series.get_es_start(start_dates, 1)
         self.assertEqual(start, 1)
         self.assertEqual(other_start, 0)
 
     def test_series_start_many_years_delay(self):
-        one_serie = self.get_serie('year')
-        other_serie = self.get_serie('year')
+        one_series = self.get_series('year')
+        other_series = self.get_series('year')
 
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(years=100)
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 50)
-        other_start = other_serie.get_es_start(start_dates, 50)
+        start = one_series.get_es_start(start_dates, 50)
+        other_start = other_series.get_es_start(start_dates, 50)
         self.assertEqual(start, 50)
         self.assertEqual(other_start, 0)
 
     def test_series_day_and_month_periodicity(self):
-        one_serie = self.get_serie('month')
-        other_serie = self.get_serie('day')
+        one_series = self.get_series('month')
+        other_series = self.get_series('day')
 
-        other_serie.add_collapse('month')
+        other_series.add_collapse('month')
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(days=1)
 
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 50)
-        other_start = other_serie.get_es_start(start_dates, 50)
+        start = one_series.get_es_start(start_dates, 50)
+        other_start = other_series.get_es_start(start_dates, 50)
 
         self.assertEqual(start, 50)
         self.assertEqual(other_start, 49)
 
     def test_series_day_and_quarter_periodicity(self):
-        one_serie = self.get_serie('quarter')
-        other_serie = self.get_serie('day')
+        one_series = self.get_series('quarter')
+        other_series = self.get_series('day')
 
-        other_serie.add_collapse('quarter')
+        other_series.add_collapse('quarter')
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(days=1)
 
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 50)
-        other_start = other_serie.get_es_start(start_dates, 50)
+        start = one_series.get_es_start(start_dates, 50)
+        other_start = other_series.get_es_start(start_dates, 50)
 
         self.assertEqual(start, 50)
         self.assertEqual(other_start, 49)
 
     def test_series_day_and_semester_periodicity(self):
-        one_serie = self.get_serie('semester')
-        other_serie = self.get_serie('day')
+        one_series = self.get_series('semester')
+        other_series = self.get_series('day')
 
-        other_serie.add_collapse('semester')
+        other_series.add_collapse('semester')
         one_start_date = datetime(2016, 1, 1)
         other_start_date = one_start_date + relativedelta(days=1)
 
-        start_dates = {one_serie.series_id: one_start_date,
-                       other_serie.series_id: other_start_date}
+        start_dates = {one_series.series_id: one_start_date,
+                       other_series.series_id: other_start_date}
 
-        start = one_serie.get_es_start(start_dates, 50)
-        other_start = other_serie.get_es_start(start_dates, 50)
+        start = one_series.get_es_start(start_dates, 50)
+        other_start = other_series.get_es_start(start_dates, 50)
 
         self.assertEqual(start, 50)
         self.assertEqual(other_start, 49)


### PR DESCRIPTION
El bug en cuestión era aplicar el parámetro start pasado por la query
del usuario directamente a cada serie, sin tener en cuenta la diferencia
entre los índices de tiempo entre ellas. Si una serie comienza mucho
después que otra, no se le debe aplicar un start (desfasaje) igual a la
serie con menor índice, sino la diferencia entre el parámetro start y
los períodos entre ella y la serie de menor índice. Este fix soluciona
problemas de "serie no encontrada" en el front end de la API cuando se
piden varias series de tiempo a la vez, una con un índice mucho menor a
las demás.
