### PR TITLE
 No indexo series sin valores

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ requests==2.21.0
 python-dateutil==2.6.1
 iso8601==0.1.12
 pydatajson==0.4.33
-series-tiempo-ar==0.2.0
+series-tiempo-ar==0.2.1
 pandas
 numpy
 pyyaml

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ requests==2.21.0
 python-dateutil==2.6.1
 iso8601==0.1.12
 pydatajson==0.4.33
-series-tiempo-ar==0.1.6
+series-tiempo-ar==0.2.0
 pandas
 numpy
 pyyaml

--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -69,7 +69,8 @@ class DistributionIndexer:
 
         # Borro las columnas que no figuren en los metadatos
         for column in df.columns:
-            if column not in fields:
+            all_null = len(df[column][df[column].notnull()]) == 0
+            if column not in fields or all_null:
                 df.drop(column, axis='columns', inplace=True)
         columns = [fields[name] for name in df.columns]
 

--- a/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/distribution_indexer.py
@@ -67,12 +67,8 @@ class DistributionIndexer:
 
         df = read_distribution_csv_as_df(distribution)
 
-        # Borro las columnas que no figuren en los metadatos
-        for column in df.columns:
-            all_null = len(df[column][df[column].notnull()]) == 0
-            if column not in fields or all_null:
-                df.drop(column, axis='columns', inplace=True)
-        columns = [fields[name] for name in df.columns]
+        self.drop_null_or_missing_fields_from_df(df, fields)
+        identifiers = [fields[name] for name in df.columns]
 
         data = df.values
         freq = freq_iso_to_pandas(get_time_index_periodicity(distribution, fields))
@@ -84,7 +80,13 @@ class DistributionIndexer:
                                       df.index[-1],
                                       freq=constants.BUSINESS_DAILY_FREQ)
 
-        return pd.DataFrame(index=new_index, data=data, columns=columns)
+        return pd.DataFrame(index=new_index, data=data, columns=identifiers)
+
+    def drop_null_or_missing_fields_from_df(self, df, fields):
+        for column in df.columns:
+            all_null = df[column].isnull().all()
+            if all_null or column not in fields:
+                df.drop(column, axis='columns', inplace=True)
 
     def add_catalog_keyword(self, actions, distribution):
         for action in actions:

--- a/series_tiempo_ar_api/libs/indexing/tests/scraper_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/scraper_tests.py
@@ -4,7 +4,7 @@ import os
 from pydatajson import DataJson
 from django.test import TestCase
 from nose.tools import raises
-from series_tiempo_ar.custom_exceptions import FieldFewValuesError
+from series_tiempo_ar.custom_exceptions import DistributionTooManyNullSeriesError
 
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask
 from series_tiempo_ar_api.libs.indexing.constants import IDENTIFIER, DOWNLOAD_URL, DATASET_IDENTIFIER
@@ -75,7 +75,7 @@ class ScrapperTests(TestCase):
         result = self.scrapper.run(distribution, catalog)
         self.assertTrue(result)
 
-    @raises(FieldFewValuesError)
+    @raises(DistributionTooManyNullSeriesError)
     def test_validate_all_null_series(self):
         catalog = DataJson(os.path.join(
             SAMPLES_DIR, 'ts_all_null_series.json'


### PR DESCRIPTION
A partir de la versión 0.2.0 de la librería series-tiempo-ar, pueden
llegar a existir series de tiempo sin ningún valor. Agrego un chequeo en
el indexador de distribuciones para desestimar estas series.
