### PR TITLE
Agrego metadatos enriquecidos: max, min, average

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -11,3 +11,4 @@ Faker==0.8.6
 python-coveralls==2.9.1
 coveralls==1.2.0
 psycopg2==2.7.3.2
+freezegun==0.3.11

--- a/series_tiempo_ar_api/apps/management/meta_keys.py
+++ b/series_tiempo_ar_api/apps/management/meta_keys.py
@@ -15,6 +15,10 @@ SECOND_TO_LAST_VALUE = 'second_to_last_value'
 LAST_PCT_CHANGE = 'last_pct_change'
 IS_UPDATED = 'is_updated'
 
+AVERAGE = 'average'
+MAX = 'max_value'
+MIN = 'min_value'
+
 
 def get(model, key):
     values = model.enhanced_meta.filter(key=key).values_list('value', flat=True)

--- a/series_tiempo_ar_api/libs/indexing/indexer/metadata.py
+++ b/series_tiempo_ar_api/libs/indexing/indexer/metadata.py
@@ -30,7 +30,10 @@ def update_enhanced_meta(serie: pd.Series, catalog_id: str, distribution_id: str
         meta_keys.LAST_VALUE: last,
         meta_keys.SECOND_TO_LAST_VALUE: second_to_last,
         meta_keys.LAST_PCT_CHANGE: last_pct_change,
-        meta_keys.IS_UPDATED: _is_series_updated(days_since_update, periodicity)
+        meta_keys.IS_UPDATED: _is_series_updated(days_since_update, periodicity),
+        meta_keys.MAX: serie.max(),
+        meta_keys.MIN: serie.min(),
+        meta_keys.AVERAGE: serie.mean(),
     }
 
     for meta_key, value in meta.items():

--- a/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
@@ -1,7 +1,6 @@
 #! coding: utf-8
 import os
 import datetime
-from unittest import skip
 
 import mock
 from django.test import TestCase
@@ -14,11 +13,11 @@ from series_tiempo_ar_api.libs.indexing.indexer.distribution_indexer import Dist
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
 
 
-@skip
 class FieldEnhancedMetaTests(TestCase):
     catalog_id = 'test_catalog'
 
     def setUp(self):
+        Catalog.objects.all().delete()
         self.catalog = Catalog.objects.create(identifier=self.catalog_id)
         dataset = self.catalog.dataset_set.create(identifier="1")
         self.distribution_id = "1.1"
@@ -100,6 +99,24 @@ class FieldEnhancedMetaTests(TestCase):
             update_enhanced_meta(df[df.columns[0]], self.catalog_id, self.distribution_id)
         self.assertEqual(meta_keys.get(self.field, meta_keys.IS_UPDATED),
                          str(True))
+
+    def test_max(self):
+        df = self.init_df()
+        update_enhanced_meta(df[df.columns[0]], self.catalog_id, self.distribution_id)
+
+        self.assertAlmostEqual(float(meta_keys.get(self.field, meta_keys.MAX)), df[df.columns[0]].max())
+
+    def test_min(self):
+        df = self.init_df()
+        update_enhanced_meta(df[df.columns[0]], self.catalog_id, self.distribution_id)
+
+        self.assertAlmostEqual(float(meta_keys.get(self.field, meta_keys.MIN)), df[df.columns[0]].min())
+
+    def test_average(self):
+        df = self.init_df()
+        update_enhanced_meta(df[df.columns[0]], self.catalog_id, self.distribution_id)
+
+        self.assertAlmostEqual(float(meta_keys.get(self.field, meta_keys.AVERAGE)), df[df.columns[0]].mean())
 
     def init_df(self):
         self.field.distribution.data_file = File(open(os.path.join(SAMPLES_DIR,

--- a/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
@@ -74,7 +74,7 @@ class FieldEnhancedMetaTests(TestCase):
 
             # Sólo válido porque la serie es diaria! Con otra periodicity hay que considerar
             # el fin del período
-            days = (datetime.datetime.today() - last_date).days
+            days = (datetime.datetime.now() - last_date).days
 
         self.assertEqual(meta_keys.get(self.field, meta_keys.DAYS_SINCE_LAST_UPDATE),
                          str(days))

--- a/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/metadata_tests.py
@@ -69,7 +69,7 @@ class FieldEnhancedMetaTests(TestCase):
         df = self.init_df()
 
         last_date = df.index[-1]  # 2003-02-03
-        with freeze_time(last_date + relativedelta(days=1)):
+        with freeze_time("2003-02-04 06:00:00"):
             update_enhanced_meta(df[df.columns[0]], self.catalog_id, self.distribution_id)
 
             # Sólo válido porque la serie es diaria! Con otra periodicity hay que considerar


### PR DESCRIPTION
Se generan cada vez que se actualiza una distribución.
Se muestran de manera automática en la respuesta del endpoint /series, cuando se pide `metadata=full` o `metadata=only`.