### PR TITLE
Refactor de legibilidad en MetadataResponse

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -160,23 +160,10 @@ class Query(object):
             ...
         }
         """
+        simple_meta = self.metadata_config == constants.METADATA_SIMPLE
+        meta_response = MetadataResponse(serie_model, simple=simple_meta, flat=self.metadata_flatten)
 
-        metadata = None
-        full_meta_values = (constants.METADATA_ONLY, constants.METADATA_FULL)
-        meta_response = MetadataResponse(serie_model)
-        if self.metadata_config in full_meta_values:
-            metadata = meta_response.get_full_metadata()
-        elif self.metadata_config == constants.METADATA_SIMPLE:
-            metadata = meta_response.get_simple_metadata()
-
-        if self.metadata_flatten:
-            for level in list(metadata):
-                for meta_field in list(metadata[level]):
-                    metadata['{}_{}'.format(level, meta_field)] = metadata[level][meta_field]
-
-                metadata.pop(level)
-
-        return metadata
+        return meta_response.get_response()
 
     def _calculate_data_frequency(self):
         """Devuelve la periodicidad de la o las series pedidas. Si son

--- a/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
@@ -20,7 +20,7 @@ class MetadataResponseTests(TestCase):
         self.field.distribution.dataset.themes = json.dumps([{'id': 'theme_id', 'label': 'test_label'}])
         self.field.distribution.dataset.save()
 
-        full_meta = MetadataResponse(self.field).get_full_metadata()
+        full_meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
 
         self.assertTrue(isinstance(full_meta['dataset']['theme'], list))
         self.assertEqual(full_meta['dataset']['theme'][0]['label'], 'test_label')


### PR DESCRIPTION
Mejor encapsulamiento del código generador de la respuesta de metadatos

Ahora MetadataResponse tiene un único método "público", `get_response`, que devuelve los metadatos de la serie según los criterios pasados como variables de instancia, de `simple`, y `flat` (booleanos)