### PR TITLE
Modos de representación como metadatos

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -140,3 +140,11 @@ IN_MEMORY_AGGS = [
 ]
 
 PARAM_LAST = 'last'
+
+VERBOSE_REP_MODES = {
+    VALUE: None,
+    CHANGE: "Variación respecto del período anterior",
+    CHANGE_YEAR_AGO: "Variación interanual",
+    PCT_CHANGE: "Variación porcentual respecto del período anterior",
+    PCT_CHANGE_YEAR_AGO: "Variación porcentual interanual",
+}

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.test import TestCase
 from nose.tools import raises
 
+from series_tiempo_ar_api.apps.api.query import constants
 from series_tiempo_ar_api.apps.management import meta_keys
 from series_tiempo_ar_api.apps.api.exceptions import CollapseError
 from django_datajsonar.models import Field
@@ -238,3 +239,21 @@ class QueryTests(TestCase):
         result = self.query.run()
 
         self.assertEqual(len(result['data']), 2)
+
+    def test_response_rep_mode_units(self):
+        self.query.add_series(self.single_series, self.field)
+
+        meta = self.query.get_metadata()
+        field_meta = meta[1]['field']
+        self.assertEqual(field_meta['representation_mode'], 'value')
+        self.assertEqual(field_meta['representation_mode_units'], meta[1]['field'].get('units'))
+
+    def test_response_rep_mode_units_pct_change(self):
+        rep_mode = constants.PCT_CHANGE
+        self.query.add_series(self.single_series, self.field, rep_mode=rep_mode)
+
+        meta = self.query.get_metadata()
+        field_meta = meta[1]['field']
+
+        self.assertEqual(field_meta['representation_mode'], rep_mode)
+        self.assertEqual(field_meta['representation_mode_units'], constants.VERBOSE_REP_MODES[rep_mode])


### PR DESCRIPTION
Agrega a los metadatos de series ('field') los campos
'representation_mode' y 'representation_mode_units'. El primer campo
tendrá como valor la copia exacta del parámetro modo de representación
pedido para la serie. El segundo, tendrá un nombre _verbose_ del modo
de representación.