### PR TITLE
Indexo queries a Elasticsearch

### DIFF
--- a/series_tiempo_ar_api/apps/analytics/elasticsearch/constants.py
+++ b/series_tiempo_ar_api/apps/analytics/elasticsearch/constants.py
@@ -1,0 +1,30 @@
+from series_tiempo_ar_api.libs.indexing.constants import \
+    VALUE, CHANGE, PCT_CHANGE, CHANGE_YEAR_AGO, PCT_CHANGE_YEAR_AGO
+
+
+SERIES_QUERY_INDEX_NAME = 'query'
+
+
+REP_MODES = [
+    VALUE,
+    CHANGE,
+    PCT_CHANGE,
+    CHANGE_YEAR_AGO,
+    PCT_CHANGE_YEAR_AGO,
+]
+
+AGG_DEFAULT = 'avg'
+AGG_SUM = 'sum'
+AGG_END_OF_PERIOD = 'end_of_period'
+AGG_MAX = 'max'
+AGG_MIN = 'min'
+AGGREGATIONS = [
+    AGG_DEFAULT,
+    AGG_SUM,
+    AGG_END_OF_PERIOD,
+    AGG_MAX,
+    AGG_MIN,
+]
+
+PARAM_REP_MODE = 'representation_mode'
+PARAM_COLLAPSE_AGG = 'collapse_aggregation'

--- a/series_tiempo_ar_api/apps/analytics/elasticsearch/doc.py
+++ b/series_tiempo_ar_api/apps/analytics/elasticsearch/doc.py
@@ -1,0 +1,17 @@
+from elasticsearch_dsl import DocType, Keyword, Object, Ip, Text, Date, Float, Integer
+
+from series_tiempo_ar_api.apps.analytics.elasticsearch import constants
+
+
+class SeriesQuery(DocType):
+
+    serie_id = Keyword()
+    params = Object()
+    ip_address = Ip()
+    user_agent = Text()
+    timestamp = Date()
+    request_time = Float()
+    status_code = Integer()
+
+    class Meta:
+        index = constants.SERIES_QUERY_INDEX_NAME

--- a/series_tiempo_ar_api/apps/analytics/elasticsearch/index.py
+++ b/series_tiempo_ar_api/apps/analytics/elasticsearch/index.py
@@ -1,0 +1,76 @@
+import json
+
+from elasticsearch.helpers import parallel_bulk
+from elasticsearch_dsl import Index
+from elasticsearch_dsl.connections import connections
+
+from . import constants
+from .doc import SeriesQuery
+from .constants import \
+    REP_MODES, AGGREGATIONS, PARAM_REP_MODE, PARAM_COLLAPSE_AGG
+
+
+class AnalyticsIndexer:
+
+    def __init__(self, index: str = constants.SERIES_QUERY_INDEX_NAME):
+        self.es_index = Index(index)
+        self.es_index.doc_type(SeriesQuery)
+        self.es_connection = connections.get_connection()
+
+    def index(self, queryset):
+        self._init_index()
+
+        for success, info in parallel_bulk(self.es_connection, generate_es_query(queryset)):
+            if not success:
+                raise RuntimeError(f"Error indexando query a ES: {info}")
+
+    def _init_index(self):
+        if not self.es_index.exists():
+            self.es_index.create()
+
+
+def generate_es_query(queryset):
+    for query in queryset:
+        series_ids = json.loads(query.ids)
+
+        for serie_string in series_ids:
+            yield construct_query_doc(query, serie_string)
+
+
+def construct_query_doc(query, serie_string) -> dict:
+    params = json.loads(query.params) if query.params else {}
+
+    serie_id = serie_string.split(':')[0]
+    params.update(get_params(serie_string))
+    return SeriesQuery(
+        meta={'id': f'{query.id}-{serie_id}'},
+        serie_id=serie_id,
+        params=params,
+        ip_address=query.ip_address,
+        user_agent=query.user_agent,
+        timestamp=query.timestamp,
+        request_time=query.request_time,
+        status_code=query.status_code
+    ).to_dict(include_meta=True)
+
+
+def get_params(serie_id: str) -> dict:
+    terms = serie_id.split(':')
+
+    result = {
+        'ids': serie_id
+    }
+
+    for term in terms[1:]:
+        key = _infer_param_key(term)
+        if key is not None:
+            result[key] = term
+
+    return result
+
+
+def _infer_param_key(value):
+    if value in REP_MODES:
+        return PARAM_REP_MODE
+    elif value in AGGREGATIONS:
+        return PARAM_COLLAPSE_AGG

--- a/series_tiempo_ar_api/apps/analytics/management/commands/index_to_es.py
+++ b/series_tiempo_ar_api/apps/analytics/management/commands/index_to_es.py
@@ -1,0 +1,19 @@
+#! coding: utf-8
+from django.core.management import BaseCommand
+from django_rq import job
+
+from series_tiempo_ar_api.apps.analytics.elasticsearch.index import AnalyticsIndexer
+from series_tiempo_ar_api.apps.analytics.models import Query
+from series_tiempo_ar_api.apps.analytics.tasks import enqueue_new_import_analytics_task
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        index_analytics.delay()
+        self.stdout.write("Indexación de queries a ES comenzada")
+
+
+@job('default', timeout=-1)
+def index_analytics():
+    queryset = Query.objects.all()
+    AnalyticsIndexer().index(queryset)

--- a/series_tiempo_ar_api/apps/analytics/tasks.py
+++ b/series_tiempo_ar_api/apps/analytics/tasks.py
@@ -4,10 +4,10 @@ from django_rq import job
 from .importer import AnalyticsImporter
 
 
-def enqueue_new_import_analytics_task(limit=1000, requests_lib=requests, import_all=False):
-    AnalyticsImporter(limit=limit, requests_lib=requests_lib).run(import_all)
+def enqueue_new_import_analytics_task(limit=1000, requests_lib=requests, import_all=False, index_to_es=True):
+    AnalyticsImporter(limit=limit, requests_lib=requests_lib, index_to_es=index_to_es).run(import_all)
 
 
 @job('analytics', timeout=1000)
-def import_analytics(task, limit=1000, requests_lib=requests, import_all=False):
-    AnalyticsImporter(task=task, limit=limit, requests_lib=requests_lib).run(import_all)
+def import_analytics(task, limit=1000, requests_lib=requests, import_all=False, index_to_es=True):
+    AnalyticsImporter(task=task, limit=limit, requests_lib=requests_lib, index_to_es=index_to_es).run(import_all)

--- a/series_tiempo_ar_api/apps/analytics/tests/es_tests.py
+++ b/series_tiempo_ar_api/apps/analytics/tests/es_tests.py
@@ -1,0 +1,58 @@
+from django.test import TestCase
+
+from series_tiempo_ar_api.apps.analytics.elasticsearch.index import get_params
+
+
+class QueryParserTests(TestCase):
+
+    def test_parse_serie_string_params(self):
+        string = 'test_serie'
+
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string})
+
+    def test_parse_serie_string_with_rep_mode(self):
+        serie_id = 'test_serie'
+        rep_mode = 'value'
+
+        string = f'{serie_id}:{rep_mode}'
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string, 'representation_mode': rep_mode})
+
+    def test_parse_serie_string_with_collapse_agg(self):
+        serie_id = 'test_serie'
+        agg = 'max'
+
+        string = f'{serie_id}:{agg}'
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string, 'collapse_aggregation': agg})
+
+    def test_parse_all_three(self):
+        serie_id = 'test_serie'
+        rep_mode = 'value'
+        agg = 'max'
+
+        string = f'{serie_id}:{rep_mode}:{agg}'
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string,
+                                      'representation_mode': rep_mode,
+                                      'collapse_aggregation': agg})
+
+    def test_parse_all_three_different_order(self):
+        serie_id = 'test_serie'
+        rep_mode = 'value'
+        agg = 'max'
+
+        string = f'{serie_id}:{agg}:{rep_mode}'
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string,
+                                      'representation_mode': rep_mode,
+                                      'collapse_aggregation': agg})
+
+    def test_invalid_params_are_ignored(self):
+        serie_id = 'test_serie'
+        rep_mode = 'invalid_value'
+
+        string = f'{serie_id}:{rep_mode}'
+        params = get_params(string)
+        self.assertDictEqual(params, {'ids': string})

--- a/series_tiempo_ar_api/apps/analytics/tests/import_tests.py
+++ b/series_tiempo_ar_api/apps/analytics/tests/import_tests.py
@@ -12,7 +12,7 @@ fake = Faker()
 class UninitializedImportConfigTests(TestCase):
 
     def test_not_initialized_model(self):
-        enqueue_new_import_analytics_task()
+        enqueue_new_import_analytics_task(index_to_es=False)
         self.assertTrue('Error' in AnalyticsImportTask.objects.last().logs)
 
 
@@ -45,7 +45,7 @@ class ImportTests(TestCase):
         config_model.save()
 
     def test_single_empty_result(self):
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([{
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([{
             'next': None,
             'count': 0,
             'results': []
@@ -54,7 +54,7 @@ class ImportTests(TestCase):
         self.assertEqual(Query.objects.count(), 0)
 
     def test_single_page_results(self):
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -72,7 +72,7 @@ class ImportTests(TestCase):
         self.assertEqual(Query.objects.count(), 1)
 
     def test_many_results(self):
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -101,7 +101,7 @@ class ImportTests(TestCase):
 
         # Borro un dato, y me aseguro que se regenera con import_all
         Query.objects.first().delete()
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -130,7 +130,7 @@ class ImportTests(TestCase):
 
         # Borro un dato. Si no le paso import_all=True, no se va a crear de nuevo
         Query.objects.all().order_by('-timestamp').last().delete()
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 0,
@@ -167,7 +167,7 @@ class ImportTests(TestCase):
                 }
             ]
         }]
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests(responses=return_value))
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests(responses=return_value))
 
         self.assertEqual(Query.objects.count(), 2)
 
@@ -187,13 +187,13 @@ class ImportTests(TestCase):
                 ]
             }
         ]
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests(results))
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests(results))
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests(results))
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests(results))
         # Esperado: que haya un solo objeto query, no se dupliquen los resultados
         self.assertEqual(Query.objects.count(), 1)
 
     def test_ignore_not_series_uri(self):
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -212,7 +212,7 @@ class ImportTests(TestCase):
 
     def test_import_uri_field(self):
         uri = '/series/api/series'
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -232,7 +232,7 @@ class ImportTests(TestCase):
 
     def test_import_status_code_field(self):
         status_code = 200
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -253,7 +253,7 @@ class ImportTests(TestCase):
 
     def test_import_user_agent_field(self):
         agent = fake.word()
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -274,7 +274,7 @@ class ImportTests(TestCase):
 
     def test_import_response_time(self):
         request_time = str(fake.pyfloat(left_digits=1, right_digits=10, positive=True))
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests([
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests([
             {
                 'next': None,
                 'count': 1,
@@ -319,6 +319,6 @@ class ImportTests(TestCase):
                 }
             ]
         }]
-        enqueue_new_import_analytics_task(requests_lib=FakeRequests(responses=return_value))
+        enqueue_new_import_analytics_task(index_to_es=False, requests_lib=FakeRequests(responses=return_value))
 
         self.assertIsNotNone(ImportConfig.get_solo().last_cursor)


### PR DESCRIPTION
Mete toda la lógica de indexación en una clase `AnalyticsIndexer`, que utiliza un documento de `elasticsearch-dsl` para indexar un queryset / iterable compuesto de modelos `Query` a Elasticsearch.

Pasa a usar esta nueva clase durante la rutina de importado de analytics, además de cargar las queries en la DB, las carga en Elasticsearch.

Agrega un nuevo management command para correr sólo la rutina de indexación a ES a partir de **todos** los modelos Query en la DB cargados, a modo de sincronización de datos. 