### PR TITLE
Metadatos de popularidad de las series

### DIFF
--- a/series_tiempo_ar_api/apps/management/meta_keys.py
+++ b/series_tiempo_ar_api/apps/management/meta_keys.py
@@ -19,6 +19,11 @@ AVERAGE = 'average'
 MAX = 'max_value'
 MIN = 'min_value'
 
+HITS_TOTAL = 'hits_total'
+HITS_30_DAYS = 'hits_30_days'
+HITS_90_DAYS = 'hits_90_days'
+HITS_180_DAYS = 'hits_180_days'
+
 
 def get(model, key):
     values = model.enhanced_meta.filter(key=key).values_list('value', flat=True)

--- a/series_tiempo_ar_api/libs/indexing/popularity.py
+++ b/series_tiempo_ar_api/libs/indexing/popularity.py
@@ -21,12 +21,20 @@ def update_popularity_metadata(distribution: Distribution):
     series_ids = series.values_list('identifier', flat=True)
 
     for meta_key, days in KEY_DAYS_PAIRS:
-        hits = popularity_aggregation(series_ids, days)
+        agg_result = popularity_aggregation(series_ids, days)
 
-        for serie in series:
-            serie_hits = hits[serie.identifier].count.value
-            serie.enhanced_meta.update_or_create(key=meta_key,
-                                                 defaults={'value': serie_hits})
+        update_series_popularity_metadata(agg_result, meta_key, series)
+
+
+def update_series_popularity_metadata(agg_result, meta_key, series):
+    for serie in series:
+        serie_hits = get_hits(serie.identifier, agg_result)
+        serie.enhanced_meta.update_or_create(key=meta_key,
+                                             defaults={'value': serie_hits})
+
+
+def get_hits(serie_id, agg_result):
+    return agg_result[serie_id].count.value
 
 
 def popularity_aggregation(series_ids: str, days: int):

--- a/series_tiempo_ar_api/libs/indexing/popularity.py
+++ b/series_tiempo_ar_api/libs/indexing/popularity.py
@@ -1,7 +1,6 @@
 from django_datajsonar.models import Distribution
 from elasticsearch_dsl import Search, Q, Index
 from series_tiempo_ar_api.apps.management import meta_keys
-from series_tiempo_ar_api.apps.analytics.elasticsearch.index import SeriesQuery
 
 KEY_DAYS_PAIRS = (
     (meta_keys.HITS_TOTAL, None),
@@ -18,27 +17,37 @@ def update_popularity_metadata(distribution: Distribution):
     series = distribution.field_set\
         .exclude(identifier='indice_tiempo')\
         .exclude(identifier=None)
-    for serie in series:
-        for meta_key, days in KEY_DAYS_PAIRS:
-            hits = popularity_aggregation(serie.identifier, days)
+
+    series_ids = series.values_list('identifier', flat=True)
+
+    for meta_key, days in KEY_DAYS_PAIRS:
+        hits = popularity_aggregation(series_ids, days)
+
+        for serie in series:
+            serie_hits = hits[serie.identifier].count.value
             serie.enhanced_meta.update_or_create(key=meta_key,
-                                                 defaults={'value': hits})
+                                                 defaults={'value': serie_hits})
 
 
-def popularity_aggregation(serie_id: str, days: int) -> int:
-    filters = [Q('term', serie_id=serie_id)]
-    if days is not None:
-        filters.append(Q('range', timestamp={'gte': f'now-{days}d'}))
-
+def popularity_aggregation(series_ids: str, days: int):
     s = Search(index='query')
     s.aggs \
         .bucket(name="hits_last_days",
-                agg_type='filter',
-                bool={'filter': filters}) \
+                agg_type='filters',
+                filters={serie_id: get_serie_filter(serie_id, days) for serie_id in series_ids})\
         .metric(name='count',
                 agg_type='value_count',
                 field='serie_id')
     s = s[:0]
 
     result = s.execute()
-    return result.aggregations.hits_last_days.count.value
+    return result.aggregations.hits_last_days.buckets
+
+
+def get_serie_filter(serie_id: str, days: int) -> dict:
+    filters = []
+    if days is not None:
+        filters.append(Q('range', timestamp={'gte': f'now-{days}d'}))
+
+    filters.append(Q('term', serie_id=serie_id))
+    return {'bool': {'filter': filters}}

--- a/series_tiempo_ar_api/libs/indexing/popularity.py
+++ b/series_tiempo_ar_api/libs/indexing/popularity.py
@@ -1,0 +1,44 @@
+from django_datajsonar.models import Distribution
+from elasticsearch_dsl import Search, Q, Index
+from series_tiempo_ar_api.apps.management import meta_keys
+from series_tiempo_ar_api.apps.analytics.elasticsearch.index import SeriesQuery
+
+KEY_DAYS_PAIRS = (
+    (meta_keys.HITS_TOTAL, None),
+    (meta_keys.HITS_30_DAYS, 30),
+    (meta_keys.HITS_90_DAYS, 90),
+    (meta_keys.HITS_180_DAYS, 180),
+)
+
+
+def update_popularity_metadata(distribution: Distribution):
+    if not Index('query').exists():
+        return
+
+    series = distribution.field_set\
+        .exclude(identifier='indice_tiempo')\
+        .exclude(identifier=None)
+    for serie in series:
+        for meta_key, days in KEY_DAYS_PAIRS:
+            hits = popularity_aggregation(serie.identifier, days)
+            serie.enhanced_meta.update_or_create(key=meta_key,
+                                                 defaults={'value': hits})
+
+
+def popularity_aggregation(serie_id: str, days: int) -> int:
+    filters = [Q('term', serie_id=serie_id)]
+    if days is not None:
+        filters.append(Q('range', timestamp={'gte': f'now-{days}d'}))
+
+    s = Search(index='query')
+    s.aggs \
+        .bucket(name="hits_last_days",
+                agg_type='filter',
+                bool={'filter': filters}) \
+        .metric(name='count',
+                agg_type='value_count',
+                field='serie_id')
+    s = s[:0]
+
+    result = s.execute()
+    return result.aggregations.hits_last_days.count.value

--- a/series_tiempo_ar_api/libs/indexing/tasks.py
+++ b/series_tiempo_ar_api/libs/indexing/tasks.py
@@ -14,6 +14,7 @@ from django_datajsonar.models import Distribution
 from series_tiempo_ar_api.apps.management import meta_keys
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask
 from series_tiempo_ar_api.libs.indexing.indexer.distribution_indexer import DistributionIndexer
+from series_tiempo_ar_api.libs.indexing.popularity import update_popularity_metadata
 from .report.report_generator import ReportGenerator
 from .scraping import Scraper
 
@@ -46,6 +47,8 @@ def index_distribution(distribution_id, node_id, task_id,
                                                           defaults={'value': distribution_model.data_hash})
         distribution_model.enhanced_meta.update_or_create(key=meta_keys.CHANGED,
                                                           defaults={'value': str(changed)})
+
+        update_popularity_metadata(distribution_model)
 
     except Exception as e:
         _handle_exception(distribution_model.dataset, distribution_id, e, node, task)

--- a/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
@@ -24,29 +24,29 @@ class PopularityTests(TestCase):
         cls.field = cls.distribution.field_set.create(identifier='test_field')
 
     def test_metadata_is_created(self, mock_hits, *_):
-        mock_hits.return_value = self.faker.pyint()
-        update_popularity_metadata(self.distribution)
+        mock_value = self._update_popularity_metadata(mock_hits)
 
         hits = int(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
-        self.assertEqual(hits, mock_hits.return_value)
+        self.assertEqual(hits, mock_value)
 
     def test_metadata_is_updated(self, mock_hits, *_):
-        first_value = self.faker.pyint()
-        mock_hits.return_value = first_value
-        update_popularity_metadata(self.distribution)
+        self._update_popularity_metadata(mock_hits)
 
-        updated_value = self.faker.pyint()
-        mock_hits.return_value = updated_value
-        update_popularity_metadata(self.distribution)
+        updated_value = self._update_popularity_metadata(mock_hits)
 
         hits = int(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
         self.assertEqual(hits, updated_value)
 
     def test_all_metadata_created(self, mock_hits, *_):
-        mock_hits.return_value = self.faker.pyint()
-        update_popularity_metadata(self.distribution)
+        self._update_popularity_metadata(mock_hits)
 
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_30_DAYS))
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_90_DAYS))
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_180_DAYS))
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
+
+    def _update_popularity_metadata(self, mock_hits):
+        mock_value = self.faker.pyint()
+        mock_hits.return_value = mock_value
+        update_popularity_metadata(self.distribution)
+        return mock_value

--- a/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+
+import faker
+import mock
+from django_datajsonar.models import Distribution, Catalog, Dataset
+
+from series_tiempo_ar_api.apps.management import meta_keys
+from series_tiempo_ar_api.libs.indexing.popularity import update_popularity_metadata
+
+
+@mock.patch('series_tiempo_ar_api.libs.indexing.popularity.popularity_aggregation')
+@mock.patch('series_tiempo_ar_api.libs.indexing.popularity.Index')
+@mock.patch('series_tiempo_ar_api.libs.indexing.popularity.get_hits')
+class PopularityTests(TestCase):
+    faker = faker.Faker()
+
+    @classmethod
+    def setUpClass(cls):
+        super(PopularityTests, cls).setUpClass()
+        catalog = Catalog.objects.create(identifier='test_catalog')
+        dataset = Dataset.objects.create(catalog=catalog)
+        cls.distribution = Distribution.objects.create(dataset=dataset, identifier='test_distribution')
+
+        cls.field = cls.distribution.field_set.create(identifier='test_field')
+
+    def test_metadata_is_created(self, mock_hits, *_):
+        mock_hits.return_value = self.faker.pyint()
+        update_popularity_metadata(self.distribution)
+
+        hits = int(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
+        self.assertEqual(hits, mock_hits.return_value)
+
+    def test_metadata_is_updated(self, mock_hits, *_):
+        first_value = self.faker.pyint()
+        mock_hits.return_value = first_value
+        update_popularity_metadata(self.distribution)
+
+        updated_value = self.faker.pyint()
+        mock_hits.return_value = updated_value
+        update_popularity_metadata(self.distribution)
+
+        hits = int(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
+        self.assertEqual(hits, updated_value)
+
+    def test_all_metadata_created(self, mock_hits, *_):
+        mock_hits.return_value = self.faker.pyint()
+        update_popularity_metadata(self.distribution)
+
+        self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_30_DAYS))
+        self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_90_DAYS))
+        self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_180_DAYS))
+        self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_TOTAL))


### PR DESCRIPTION
Utiliza el índice de queries de Elasticsearch generado previamente para calcular la cantidad de consultas a todas las series en distintos intervalos de tiempo:
- Últimos 30 días
- Últimos 90 días
- Últimos 180 días
- Histórico completo

Estos metadatos se calculan para *todas* las series, *todos* los días, se estén actualizando o no las distribuciones