### PR TITLE
Corrijo agregado de series con distintas freqs

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/pipeline.py
+++ b/series_tiempo_ar_api/apps/api/query/pipeline.py
@@ -368,7 +368,7 @@ class Collapse(BaseOperation):
             return
 
         try:
-            query.add_collapse(collapse=collapse)
+            query.update_collapse(collapse=collapse)
         except CollapseError:
             msg = strings.INVALID_COLLAPSE.format(collapse)
             self._append_error(msg)

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/sort_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/sort_tests.py
@@ -51,7 +51,7 @@ class SortTests(TestCase):
     def test_sort_desc_with_collapse(self):
         self.query.add_series(self.single_series, self.field, 'value')
         self.cmd.run(self.query, {'sort': 'desc'})
-        self.query.add_collapse(collapse='year')
+        self.query.update_collapse(collapse='year')
         data = self.query.run()['data']
 
         previous = iso8601.parse_date(data[0][0])
@@ -63,7 +63,7 @@ class SortTests(TestCase):
     def test_sort_asc_with_collapse(self):
         self.query.add_series(self.single_series, self.field, 'value')
         self.cmd.run(self.query, {'sort': 'asc'})
-        self.query.add_collapse('year')
+        self.query.update_collapse('year')
         data = self.query.run()['data']
 
         previous = iso8601.parse_date(data[0][0])

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -43,7 +43,7 @@ class QueryTests(TestCase):
     def test_collapse_index_metadata_frequency(self):
         collapse_interval = 'quarter'
         self.query.add_series(self.single_series, self.field)
-        self.query.add_collapse(collapse=collapse_interval)
+        self.query.update_collapse(collapse=collapse_interval)
         self.query.run()
 
         index_frequency = self.query.get_metadata()[0]['frequency']
@@ -52,7 +52,7 @@ class QueryTests(TestCase):
     def test_collapse_index_metadata_start_end_dates(self):
         collapse_interval = 'quarter'
         self.query.add_series(self.single_series, self.field)
-        self.query.add_collapse(collapse=collapse_interval)
+        self.query.update_collapse(collapse=collapse_interval)
         data = self.query.run()['data']
 
         index_meta = self.query.get_metadata()[0]
@@ -63,7 +63,7 @@ class QueryTests(TestCase):
     def test_invalid_collapse(self):
         collapse_interval = 'day'  # Serie cargada es mensual
         self.query.add_series(self.single_series, self.field)
-        self.query.add_collapse(collapse=collapse_interval)
+        self.query.update_collapse(collapse=collapse_interval)
 
     def test_identifiers(self):
 
@@ -81,7 +81,7 @@ class QueryTests(TestCase):
 
         self.query.add_series(day_series_name, field)
 
-        self.query.add_collapse(collapse='week')
+        self.query.update_collapse(collapse='week')
         self.query.sort(how='asc')
         data = self.query.run()['data']
 
@@ -213,7 +213,7 @@ class QueryTests(TestCase):
 
     def test_full_metadata_periodicty_with_collapse(self):
         self.query.add_series(self.single_series, self.field)
-        self.query.add_collapse('year')
+        self.query.update_collapse('year')
         self.query.set_metadata_config('full')
 
         resp = self.query.run()


### PR DESCRIPTION
Refactor al método de agregado de series para que siempre se actualicen todas las frecuencias de todas las series a la de mayor frecuencia. Por ejemplo, si se piden 3 series, una anual y dos mensuales, en cada llamada al agregado de series se actualiza la frecuencia para que sea la mayor (anual), y asegurarse que no quede configurada una frecuencia mensual (sería inválido)