### PR TITLE
Valido la existencia de metadatos de series

### DIFF
--- a/series_tiempo_ar_api/apps/api/tests/helpers.py
+++ b/series_tiempo_ar_api/apps/api/tests/helpers.py
@@ -70,6 +70,7 @@ def init_month_series(dataset):
     field.save()
     field.enhanced_meta.create(key=meta_keys.AVAILABLE, value='True')
     field.enhanced_meta.create(key=meta_keys.PERIODICITY, value='R/P1M')
+    field.enhanced_meta.create(key=meta_keys.INDEX_START, value='1910-01-01')
 
     return dataset
 

--- a/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/pipeline_tests/ids_tests.py
@@ -1,12 +1,13 @@
 #! coding: utf-8
 from django.conf import settings
 from django.test import TestCase
+from django_datajsonar.models import Field
 
 from series_tiempo_ar_api.apps.api.query.pipeline import \
     IdsField
 from series_tiempo_ar_api.apps.api.query.query import Query
 from series_tiempo_ar_api.apps.api.query.strings import SERIES_DOES_NOT_EXIST
-from series_tiempo_ar_api.apps.api.tests.helpers import setup_database
+from series_tiempo_ar_api.apps.management import meta_keys
 from ..helpers import get_series_id
 from ..support.pipeline import time_serie_name
 
@@ -157,3 +158,9 @@ class IdsTest(TestCase):
 
         self.cmd.run(self.query, {'ids': multi_series})
         self.assertIn(invalid, self.cmd.failed_series)
+
+    def test_serie_without_index_start(self):
+        Field.objects.get(identifier=self.single_series).enhanced_meta.get(key=meta_keys.INDEX_START).delete()
+        self.cmd.run(self.query, {'ids': self.single_series})
+
+        self.assertTrue(self.cmd.errors)

--- a/series_tiempo_ar_api/apps/management/meta_keys.py
+++ b/series_tiempo_ar_api/apps/management/meta_keys.py
@@ -1,5 +1,6 @@
 #!coding=utf8
 """Keys para usar junto con los campos de enhanced_meta que provee django datajsonar"""
+from typing import Optional
 
 AVAILABLE = 'available'
 PERIODICITY = 'frequency'
@@ -27,7 +28,7 @@ HITS_180_DAYS = 'hits_180_days'
 HITS_KEYS = (HITS_180_DAYS, HITS_90_DAYS, HITS_30_DAYS, HITS_TOTAL)
 
 
-def get(model, key):
+def get(model, key) -> Optional[str]:
     values = model.enhanced_meta.filter(key=key).values_list('value', flat=True)
 
     if values:


### PR DESCRIPTION
Un metadato en particular, INDEX_START, se volvió esencial para el
funcionamiento correcto de la API frente a pedidos de varias series de
tiempo. Se agrega un chequeo de existencia sobre cada serie pedida, para
evitar errores en el armado de la respuesta si el metadato no es
encontrado

Closes #471 