### PR TITLE
Muestro cantidad de hits en endpoints auxiliares

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/queries/query_terms.py
+++ b/series_tiempo_ar_api/apps/metadata/queries/query_terms.py
@@ -22,7 +22,8 @@ def query_field_terms(field=None):
     search = search[:0]  # Descarta resultados de search, solo nos importa el aggregation
     search_result = search.execute()
 
-    sources = [source['key'] for source in search_result.aggregations.results.buckets]
+    sources = [{"label": source['key'], "series_count": source['doc_count']}
+               for source in search_result.aggregations.results.buckets]
     response = {
         'data': sources
     }

--- a/series_tiempo_ar_api/apps/metadata/tests/field_term_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/field_term_tests.py
@@ -13,11 +13,12 @@ class FieldTermsTest(TestCase):
     def test_run(self):
         test_value = 'test_value'
         search_mock = mock.MagicMock()
-        search_mock.aggregations.results.buckets = [{'key': test_value}]
+        search_mock.aggregations.results.buckets = [{'key': test_value, 'doc_count': 1}]
 
         with mock.patch.object(Search, 'execute', return_value=search_mock):
             terms = query_field_terms(field='test_field')['data']
-            self.assertIn(test_value, terms)
+            result = terms[0]['label']
+            self.assertEqual(test_value, result)
 
     @raises(ValueError)
     def test_no_params(self):

--- a/series_tiempo_ar_api/apps/metadata/tests/view_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/view_tests.py
@@ -29,12 +29,12 @@ class DatasetSourceTests(TestCase):
     def test_run(self):
         test_source = 'test_source'
         search_mock = mock.MagicMock()
-        search_mock.aggregations.results.buckets = [{'key': test_source}]
+        search_mock.aggregations.results.buckets = [{'key': test_source, 'doc_count': 1}]
 
         with mock.patch.object(Search, 'execute', return_value=search_mock):
             response = self.client.get(reverse('api:metadata:dataset_source'))
-            response_sources = json.loads(response.content)['data']
-            self.assertIn(test_source, response_sources)
+            response_sources = json.loads(response.content)['data'][0]
+            self.assertIn(test_source, response_sources['label'])
 
 
 class FieldUnitTests(TestCase):
@@ -42,13 +42,13 @@ class FieldUnitTests(TestCase):
     def test_run(self):
         test_unit = 'test_unit'
         search_mock = mock.MagicMock()
-        search_mock.aggregations.results.buckets = [{'key': test_unit}]
+        search_mock.aggregations.results.buckets = [{'key': test_unit, 'doc_count': 1}]
 
         with mock.patch.object(Search, 'execute', return_value=search_mock):
             response = self.client.get(reverse('api:metadata:field_units'))
-            response_sources = json.loads(response.content)['data']
+            response_sources = json.loads(response.content)['data'][0]
             # Expected: search results in 'data' list
-            self.assertIn(test_unit, response_sources)
+            self.assertIn(test_unit, response_sources['label'])
 
 
 class PublisherNameTests(TestCase):
@@ -56,13 +56,13 @@ class PublisherNameTests(TestCase):
     def test_run(self):
         test_unit = 'Test publisher name'
         search_mock = mock.MagicMock()
-        search_mock.aggregations.results.buckets = [{'key': test_unit}]
+        search_mock.aggregations.results.buckets = [{'key': test_unit, 'doc_count': 1}]
 
         with mock.patch.object(Search, 'execute', return_value=search_mock):
             response = self.client.get(reverse('api:metadata:dataset_publisher_name'))
-            response_sources = json.loads(response.content)['data']
+            response_sources = json.loads(response.content)['data'][0]
             # Expected: search results in 'data' list
-            self.assertIn(test_unit, response_sources)
+            self.assertIn(test_unit, response_sources['label'])
 
 
 class CatalogIDTests(TestCase):
@@ -70,10 +70,10 @@ class CatalogIDTests(TestCase):
     def test_run(self):
         test_unit = 'Test_catalog_id'
         search_mock = mock.MagicMock()
-        search_mock.aggregations.results.buckets = [{'key': test_unit}]
+        search_mock.aggregations.results.buckets = [{'key': test_unit, 'doc_count': 1}]
 
         with mock.patch.object(Search, 'execute', return_value=search_mock):
             response = self.client.get(reverse('api:metadata:catalog_id'))
-            response_sources = json.loads(response.content)['data']
+            response_sources = json.loads(response.content)['data'][0]
             # Expected: search results in 'data' list
-            self.assertIn(test_unit, response_sources)
+            self.assertIn(test_unit, response_sources['label'])


### PR DESCRIPTION
Simplemente muestro el resultado de `doc_count` que ya se estaba calculando previamente. 

Closes #476, closes #477 