### PR TITLE
Muestro si una serie es porcentual en la respuesta

### DIFF
--- a/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
@@ -1,17 +1,24 @@
 #! coding: utf-8
 import json
+
+import faker
 from django.test import TestCase
 from django_datajsonar.models import Field
 
 from series_tiempo_ar_api.apps.api.tests.helpers import get_series_id
 from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
+from series_tiempo_ar_api.apps.metadata.models import SeriesUnits
 
 
 class MetadataResponseTests(TestCase):
     single_series = get_series_id('month')
+    faker = faker.Faker()
 
     def setUp(self):
+        self.units = self.faker.pystr()
         self.field = Field.objects.get(identifier=self.single_series)
+        self.field.metadata = json.dumps({'units': self.units})
+        self.field.save()
 
     def test_theme_labels(self):
         meta = json.loads(self.field.distribution.dataset.metadata)
@@ -24,3 +31,29 @@ class MetadataResponseTests(TestCase):
 
         self.assertTrue(isinstance(full_meta['dataset']['theme'], list))
         self.assertEqual(full_meta['dataset']['theme'][0]['label'], 'test_label')
+
+    def test_percentage_metadata_not_available_if_simple(self):
+        simple_meta = MetadataResponse(self.field, simple=True, flat=False).get_response()
+        self.assertNotIn('is_percentage', simple_meta['field'])
+
+    def test_percentage_metadata_is_false_if_no_series_units_model(self):
+        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
+        self.assertFalse(meta['field']['is_percentage'])
+
+    def test_percentage_metadata_false_if_no_units_field(self):
+        self.field.metadata = '{}'
+        self.field.save()
+        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
+        self.assertFalse(meta['field']['is_percentage'])
+
+    def test_percentage_metadata_false_if_units_arent_percentage(self):
+        SeriesUnits.objects.create(name=self.units, percentage=False)
+
+        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
+        self.assertFalse(meta['field']['is_percentage'])
+
+    def test_percent_metadata_true_if_units_are_percentage(self):
+        SeriesUnits.objects.create(name=self.units, percentage=True)
+
+        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
+        self.assertTrue(meta['field']['is_percentage'])

--- a/series_tiempo_ar_api/apps/metadata/admin.py
+++ b/series_tiempo_ar_api/apps/metadata/admin.py
@@ -3,11 +3,12 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib import messages
+from django.db.models import QuerySet
 from django_datajsonar.admin.tasks import AbstractTaskAdmin
 from django_datajsonar.models import Field
 
 from series_tiempo_ar_api.libs.singleton_admin import SingletonAdmin
-from .models import IndexMetadataTask, CatalogAlias, Synonym, MetadataConfig
+from .models import IndexMetadataTask, CatalogAlias, Synonym, MetadataConfig, SeriesUnits
 from .indexer.metadata_indexer import run_metadata_indexer
 
 
@@ -35,3 +36,18 @@ class SynonymAdmin(admin.ModelAdmin):
 @admin.register(MetadataConfig)
 class MetadataConfigAdmin(SingletonAdmin):
     pass
+
+
+@admin.register(SeriesUnits)
+class SeriesUnitsAdmin(admin.ModelAdmin):
+    list_display = ('name', 'percentage')
+    actions = ('enable_percentage', 'disable_percentage')
+
+    def enable_percentage(self, _, queryset: QuerySet):
+        queryset.update(percentage=True)
+
+    enable_percentage.short_description = 'Marcar como unidad porcentual'
+
+    def disable_percentage(self, _, queryset: QuerySet):
+        queryset.update(percentage=False)
+    disable_percentage.short_description = 'Marcar como unidad no porcentual'


### PR DESCRIPTION
El hecho que una serie es porcentual o no se decide a través del panel de administración, donde se pueden marcar manualmente a las unidades de series como porcentuales o no (por default no lo son)

Closes #479 