### PR TITLE
Leo el índice de tiempo desde metadatos durante indexación

### DIFF
--- a/series_tiempo_ar_api/libs/field_utils.py
+++ b/series_tiempo_ar_api/libs/field_utils.py
@@ -1,18 +1,39 @@
+import json
+
 from django.contrib.contenttypes.models import ContentType
-from django_datajsonar.models import Field, Metadata
+from django_datajsonar.models import Field, Metadata, Distribution
 
 from series_tiempo_ar_api.apps.management import meta_keys
+from series_tiempo_ar_api.libs.indexing import constants
+
+
+class SeriesRepository:
+
+    @staticmethod
+    def get_available_series(*args, **kwargs):
+        field_content_type = ContentType.objects.get_for_model(Field)
+        available_fields = Metadata.objects.filter(
+            key=meta_keys.AVAILABLE,
+            value='true',
+            content_type=field_content_type).values_list('object_id', flat=True)
+        fields = SeriesRepository.get_present_series(*args, **kwargs)\
+            .filter(id__in=available_fields)
+        return fields
+
+    @staticmethod
+    def get_present_series(*args, **kwargs):
+        return Field.objects.filter(present=True, error=False, *args, **kwargs)
+
+
+def get_distribution_time_index(distribution: Distribution) -> Field:
+    fields = distribution.field_set.filter(present=True)
+    for field in fields:
+        meta = json.loads(field.metadata)
+        if meta.get(constants.SPECIAL_TYPE) == constants.TIME_INDEX:
+            return field
+
+    raise Field.DoesNotExist
 
 
 def get_available_series(*args, **kwargs):
-    field_content_type = ContentType.objects.get_for_model(Field)
-    available_fields = Metadata.objects.filter(
-        key=meta_keys.AVAILABLE,
-        value='true',
-        content_type=field_content_type).values_list('object_id', flat=True)
-    fields = Field.objects.filter(
-        id__in=available_fields,
-        present=True,
-        error=False,
-    ).filter(*args, **kwargs)
-    return fields
+    return SeriesRepository.get_available_series(*args, **kwargs)

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -34,12 +34,11 @@ class IndexerTests(TestCase):
         self._index_catalog('full_ts_data.json')
 
         distribution = Distribution.objects.get(identifier="212.1")
-        fields = distribution.field_set.all()
-        fields = {field.title: field.identifier for field in fields}
-        df = DistributionIndexer(self.test_index).init_df(distribution, fields)
+        time_index = distribution.field_set.first()
+        df = DistributionIndexer(self.test_index).init_df(distribution, time_index)
 
-        for field in fields.values():
-            self.assertTrue(field in df.columns)
+        for field in distribution.field_set.exclude(id=time_index.id):
+            self.assertTrue(field.identifier in df.columns)
 
     def test_indexing(self):
         self._index_catalog('full_ts_data.json')

--- a/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/reader_tests.py
@@ -11,6 +11,8 @@ from elasticsearch_dsl.connections import connections
 from django_datajsonar.tasks import read_datajson
 from django_datajsonar.models import Distribution, Field, Catalog
 from django_datajsonar.models import ReadDataJsonTask, Node
+
+from series_tiempo_ar_api.libs.field_utils import SeriesRepository
 from series_tiempo_ar_api.utils import utils
 from series_tiempo_ar_api.apps.management import meta_keys
 from series_tiempo_ar_api.apps.management.models import ReadDataJsonTask as ManagementTask
@@ -213,6 +215,10 @@ class IndexerTests(TestCase):
     def _index_catalog(self, catalog_path, node=None):
         path = os.path.join(SAMPLES_DIR, catalog_path)
         utils.index_catalog(CATALOG_ID, path, self.test_index, node=node)
+
+    def test_different_time_index_name(self):
+        self._index_catalog('different_time_index_name.json')
+        self.assertEqual(SeriesRepository.get_available_series().count(), 1)
 
 
 @mock.patch("series_tiempo_ar_api.libs.indexing.tasks.DistributionIndexer.reindex")

--- a/series_tiempo_ar_api/libs/indexing/tests/samples/different_time_index_name.csv
+++ b/series_tiempo_ar_api/libs/indexing/tests/samples/different_time_index_name.csv
@@ -1,0 +1,3 @@
+otro_title_que_no_es_indice_tiempo,indicador
+2018-05-01,1
+2018-06-01,20

--- a/series_tiempo_ar_api/libs/indexing/tests/samples/different_time_index_name.json
+++ b/series_tiempo_ar_api/libs/indexing/tests/samples/different_time_index_name.json
@@ -1,0 +1,94 @@
+{
+  "title": "Datos Argentina",
+  "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+  "publisher": {
+    "name": "Ministerio de Modernización",
+    "mbox": "datos@modernizacion.gob.ar"
+  },
+  "issued": "2016-04-14T19:48:05.433640-03:00",
+  "modified": "2016-04-19T19:48:05.433640-03:00",
+  "language": [
+    "spa"
+  ],
+  "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+  "license": "Open Data Commons Open Database License 1.0",
+  "homepage": "http://datos.gob.ar",
+  "rights": "Derechos especificados en la licencia.",
+  "spatial": "ARG",
+  "dataset": [
+    {
+      "publisher": {
+        "mbox": "datoseconomicos@mecon.gov.ar",
+        "name": "Subsecretaría de Programación Macroeconómica."
+      },
+      "landingPage": "https://www.minhacienda.gob.ar/secretarias/politica-economica/programacion-macroeconomica/",
+      "description": "Principales tasas de interés a plazo publicadas por el BCRA. Promedios mensuales. En % n.a.",
+      "superTheme": [
+        "ECON"
+      ],
+      "title": "Principales tasas de interés",
+      "language": [
+        "SPA"
+      ],
+      "issued": "2017-09-28",
+      "temporal": "1996-01-01/2017-05-01",
+      "modified": "2018-01-03T07:00:02.849550-03:00",
+      "source": "Banco Central de la República Argentina (BCRA)",
+      "theme": [
+        "moneda"
+      ],
+      "keyword": [
+        "Información económica al día",
+        "Dinero y Bancos"
+      ],
+      "accrualPeriodicity": "R/P1D",
+      "spatial": "ARG",
+      "identifier": "89",
+      "contactPoint": {
+        "fn": "Subsecretaría de Programación Macroeconómica."
+      },
+      "accessLevel": "ABIERTO",
+      "distribution": [
+        {
+          "accessURL": "https://www.minhacienda.gob.ar/secretarias/politica-economica/programacion-macroeconomica/",
+          "scrapingFileSheet": "8.1 Tasas de interes",
+          "description": "Tasa de interés caja de ahorro, tasa de interés plazo fijo, call, prime, adelantos en cuenta corriente y Badlar, valores diarios",
+          "title": "Principales tasas de interés. Valores diarios",
+          "dataset_identifier": "89",
+          "issued": "2017-09-28",
+          "format": "CSV",
+          "modified": "2018-01-03T07:00:02.849550-03:00",
+          "fileName": "principales-tasas-interes-diarias.csv",
+          "downloadURL": "series_tiempo_ar_api/libs/indexing/tests/samples/different_time_index_name.csv",
+          "field": [
+            {
+              "distribution_identifier": "89.2",
+              "title": "otro_title_que_no_es_indice_tiempo",
+              "dataset_identifier": "89",
+              "scrapingIdentifierCell": "A301",
+              "specialTypeDetail": "R/P1M",
+              "specialType": "time_index",
+              "type": "date",
+              "id": "test_time_index",
+              "scrapingDataStartCell": "A302"
+            },
+            {
+              "distribution_identifier": "89.2",
+              "description": "Tasas de interés publicadas por el BCRA. Call. Datos diarios. En porcentaje",
+              "title": "indicador",
+              "dataset_identifier": "89",
+              "scrapingIdentifierCell": "E301",
+              "units": "Porcentaje",
+              "type": "number",
+              "id": "test_time_series",
+              "scrapingDataStartCell": "E302"
+            }
+          ],
+          "draft": false,
+          "identifier": "89.2",
+          "scrapingFileURL": "https://www.economia.gob.ar/download/infoeco/apendice8.xlsx"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Antes se buscaba al índice de tiempo tomando la columna con título `INDEX_COLUMN`. Si no existía se lanzaba excepción.

Con este PR se pasa a buscar el título del índice de tiempo en los metadatos de la distribución, buscando sobre las series aquella que tenga `specialType == "time_index`. La ventaja de este cambio es poder indexar distribuciones con títulos arbitrarios, no tienen que valer `INDEX_COLUMN`.

