### PR TITLE
Indexo las series si están disponibles

### DIFF
--- a/series_tiempo_ar_api/apps/metadata/indexer/catalog_meta_indexer.py
+++ b/series_tiempo_ar_api/apps/metadata/indexer/catalog_meta_indexer.py
@@ -13,6 +13,7 @@ from series_tiempo_ar_api.apps.management import meta_keys
 from series_tiempo_ar_api.apps.metadata import constants
 from series_tiempo_ar_api.apps.metadata.indexer.index import init_index
 from series_tiempo_ar_api.apps.metadata.models import IndexMetadataTask
+from series_tiempo_ar_api.libs.datajsonar_repositories.series_repository import SeriesRepository
 
 
 class CatalogMetadataIndexer:
@@ -87,18 +88,9 @@ class CatalogMetadataIndexer:
             yield doc
 
     def get_available_fields(self):
-        field_content_type = ContentType.objects.get_for_model(Field)
-        available_fields = Metadata.objects.filter(
-            key=meta_keys.AVAILABLE,
-            value='true',
-            content_type=field_content_type).values_list('object_id', flat=True)
-        fields = Field.objects.filter(
-            distribution__dataset__catalog__identifier=self.node.catalog_id,
-            id__in=available_fields,
-            present=True,
-            error=False,
+        return SeriesRepository.get_available_series(
+            distribution__dataset__catalog__identifier=self.node.catalog_id
         )
-        return fields
 
     def init_fields_meta_cache(self):
         field_content_type = ContentType.objects.get_for_model(Field)

--- a/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
@@ -34,27 +34,28 @@ class IndexerTests(TestCase):
         self.meta_task = IndexMetadataTask.objects.create()
 
     def test_index(self):
-        index_ok = self._index(catalog_id='test_catalog', catalog_url='single_distribution.json')
+        series_indexed = self._index(catalog_id='test_catalog',
+                                     catalog_url='single_distribution.json')
         search = Search(
             index=self.fake_index._name,
         ).filter('term',
                  catalog_id='test_catalog')
-        self.assertTrue(index_ok)
+        self.assertTrue(series_indexed)
         self.assertTrue(search.execute())
 
     def test_index_unavailable_fields(self):
-        index_ok = self._index(catalog_id='test_catalog',
-                               catalog_url='single_distribution.json',
-                               set_availables=False)
+        series_indexed = self._index(catalog_id='test_catalog',
+                                     catalog_url='single_distribution.json',
+                                     set_availables=False)
 
-        self.assertFalse(index_ok)
+        self.assertFalse(series_indexed)
 
     def test_errored_fields(self):
-        index_ok = self._index(catalog_id='test_catalog',
-                               catalog_url='single_distribution.json',
-                               set_error=True)
+        series_indexed = self._index(catalog_id='test_catalog',
+                                     catalog_url='single_distribution.json',
+                                     set_error=True)
 
-        self.assertTrue(index_ok)
+        self.assertTrue(series_indexed)
 
     def test_non_present_fields(self):
         series_indexed = self._index(catalog_id='test_catalog',

--- a/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
@@ -7,7 +7,7 @@ import faker
 from elasticsearch_dsl import Index, Search
 from django.test import TestCase
 from django_datajsonar.tasks import read_datajson
-from django_datajsonar.models import ReadDataJsonTask, Node, Field as datajsonar_Field
+from django_datajsonar.models import ReadDataJsonTask, Node, Field as datajsonar_Field, Catalog
 from elasticsearch_dsl.connections import connections
 
 from series_tiempo_ar_api.apps.metadata.indexer.catalog_meta_indexer import CatalogMetadataIndexer
@@ -17,13 +17,17 @@ from series_tiempo_ar_api.apps.management import meta_keys
 
 SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
 
-fake = faker.Faker()
-
-fake_index = Index(fake.pystr(max_chars=50).lower())
-add_analyzer(fake_index)
-
 
 class IndexerTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(IndexerTests, cls).setUpClass()
+        Catalog.objects.all().delete()
+        fake = faker.Faker()
+
+        cls.fake_index = Index(fake.pystr(max_chars=50).lower())
+        add_analyzer(cls.fake_index)
 
     def setUp(self):
         self.task = ReadDataJsonTask.objects.create()
@@ -32,7 +36,7 @@ class IndexerTests(TestCase):
     def test_index(self):
         index_ok = self._index(catalog_id='test_catalog', catalog_url='single_distribution.json')
         search = Search(
-            index=fake_index._name,
+            index=self.fake_index._name,
         ).filter('term',
                  catalog_id='test_catalog')
         self.assertTrue(index_ok)
@@ -45,6 +49,13 @@ class IndexerTests(TestCase):
 
         self.assertFalse(index_ok)
 
+    def test_errored_fields(self):
+        index_ok = self._index(catalog_id='test_catalog',
+                               catalog_url='single_distribution.json',
+                               set_error=True)
+
+        self.assertTrue(index_ok)
+
     def test_multiple_catalogs(self):
         self._index(catalog_id='test_catalog',
                                catalog_url='single_distribution.json')
@@ -53,18 +64,18 @@ class IndexerTests(TestCase):
                     catalog_url='second_single_distribution.json')
 
         search = Search(
-            index=fake_index._name,
+            index=self.fake_index._name,
         ).filter('term',
                  catalog_id='test_catalog')
         self.assertTrue(search.execute())
 
         other_search = Search(
-            index=fake_index._name,
+            index=self.fake_index._name,
         ).filter('term',
                  catalog_id='other_catalog')
         self.assertTrue(other_search.execute())
 
-    def _index(self, catalog_id, catalog_url, set_availables=True):
+    def _index(self, catalog_id, catalog_url, set_availables=True, set_error=False):
         node = Node.objects.create(
             catalog_id=catalog_id,
             catalog_url=os.path.join(SAMPLES_DIR, catalog_url),
@@ -77,11 +88,13 @@ class IndexerTests(TestCase):
                 field.enhanced_meta.create(key=meta_keys.AVAILABLE, value='true')
                 field.enhanced_meta.create(key=meta_keys.HITS_90_DAYS, value='0')
 
-        index_ok = CatalogMetadataIndexer(node, self.meta_task, fake_index._name).index()
+        datajsonar_Field.objects.update(error=set_error)
+
+        index_ok = CatalogMetadataIndexer(node, self.meta_task, self.fake_index._name).index()
         if index_ok:
             connections.get_connection().indices.forcemerge()
         return index_ok
 
     def tearDown(self):
-        if fake_index.exists():
-            fake_index.delete()
+        if self.fake_index.exists():
+            self.fake_index.delete()

--- a/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/indexer_tests.py
@@ -56,6 +56,13 @@ class IndexerTests(TestCase):
 
         self.assertTrue(index_ok)
 
+    def test_non_present_fields(self):
+        series_indexed = self._index(catalog_id='test_catalog',
+                                     catalog_url='single_distribution.json',
+                                     set_present=False)
+
+        self.assertTrue(series_indexed)
+
     def test_multiple_catalogs(self):
         self._index(catalog_id='test_catalog',
                                catalog_url='single_distribution.json')
@@ -75,7 +82,7 @@ class IndexerTests(TestCase):
                  catalog_id='other_catalog')
         self.assertTrue(other_search.execute())
 
-    def _index(self, catalog_id, catalog_url, set_availables=True, set_error=False):
+    def _index(self, catalog_id, catalog_url, set_availables=True, set_error=False, set_present=True):
         node = Node.objects.create(
             catalog_id=catalog_id,
             catalog_url=os.path.join(SAMPLES_DIR, catalog_url),
@@ -88,7 +95,7 @@ class IndexerTests(TestCase):
                 field.enhanced_meta.create(key=meta_keys.AVAILABLE, value='true')
                 field.enhanced_meta.create(key=meta_keys.HITS_90_DAYS, value='0')
 
-        datajsonar_Field.objects.update(error=set_error)
+        datajsonar_Field.objects.update(error=set_error, present=set_present)
 
         index_ok = CatalogMetadataIndexer(node, self.meta_task, self.fake_index._name).index()
         if index_ok:


### PR DESCRIPTION
Antes: Se indexaban las series que estén disponibles **y** no tengan error, **y** estén presentes. Ese comportamiento era erróneo, pues una serie con error que esté disponible puede seguir siendo consultada, idem con una serie ya no más presente. Se corrige ese comportamiento, indexando todas las series disponibles sin filtros adicionales, y se agregan pruebas de regresión.
