### PR TITLE
Improve popularity metadata update

### DIFF
--- a/series_tiempo_ar_api/libs/indexing/popularity.py
+++ b/series_tiempo_ar_api/libs/indexing/popularity.py
@@ -39,7 +39,7 @@ def update_popularity_metadata(distribution: Distribution):
 def update_series_popularity_metadata(agg_result, meta_key, series):
     field_content_type = ContentType.objects.get_for_model(Field)
     metas = Metadata.objects.filter(content_type=field_content_type,
-                                    object_id=series.values_list('id', flat=True),
+                                    object_id__in=series.values_list('id', flat=True),
                                     key=meta_key)
 
     new_metadata = []

--- a/series_tiempo_ar_api/libs/indexing/popularity.py
+++ b/series_tiempo_ar_api/libs/indexing/popularity.py
@@ -45,12 +45,12 @@ def update_series_popularity_metadata(agg_result, meta_key, series):
     new_metadata = []
     for serie in series:
         serie_hits = get_hits(serie.identifier, agg_result)
-        new_metadata.append(Metadata.objects.create(content_type=field_content_type,
-                                                    object_id=serie.id,
-                                                    key=meta_key,
-                                                    value=serie_hits))
-    with transaction.atomic():
-        metas.delete()
+        new_metadata.append(Metadata(content_type=field_content_type,
+                                     object_id=serie.id,
+                                     key=meta_key,
+                                     value=serie_hits))
+        with transaction.atomic():
+            metas.delete()
         Metadata.objects.bulk_create(new_metadata)
 
 

--- a/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/popularity_metadata_tests.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from django.test import TestCase
 
 import faker
 import mock
@@ -46,6 +46,14 @@ class PopularityTests(TestCase):
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_90_DAYS))
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_180_DAYS))
         self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
+
+    def test_update_metadata_for_many_series(self, mock_hits, *_):
+        other_field = self.distribution.field_set.create(identifier='other_field')
+        other_field.enhanced_meta.create(key=meta_keys.AVAILABLE, value='true')
+        self._update_popularity_metadata(mock_hits)
+
+        self.assertTrue(meta_keys.get(self.field, meta_keys.HITS_TOTAL))
+        self.assertTrue(meta_keys.get(other_field, meta_keys.HITS_TOTAL))
 
     def _update_popularity_metadata(self, mock_hits):
         mock_value = self.faker.pyint()


### PR DESCRIPTION
Antes se usaba update_or_create que traía un gran cuello de botella. Pasamos a actualizar los metadatos borrandolos todos y regenerandolos con bulk_create