### PR TITLE
Filtro errores sólo para el catálogo actual

### DIFF
--- a/series_tiempo_ar_api/libs/indexing/report/report_generator.py
+++ b/series_tiempo_ar_api/libs/indexing/report/report_generator.py
@@ -85,7 +85,7 @@ class ReportGenerator:
             mail_sender.add_csv_attachment(file_name, body)
 
         # No se manda si task.logs está vacío
-        mail_sender.add_plaintext_attachment('errors.log', self.task.logs)
+        mail_sender.add_plaintext_attachment('errors.log', self.error_log(node))
 
     def _format_date(self, date):
         return timezone.localtime(date).strftime(self.DATE_FORMAT)
@@ -115,3 +115,11 @@ class ReportGenerator:
                                      timestamp__year=yesterday.year).count()
 
         return count
+
+    def error_log(self, node=None):
+        errored_distributions = DistributionRepository.get_all_errored()
+        if node:
+            errored_distributions = errored_distributions.filter(
+                dataset__catalog__identifier=node.catalog_id)
+        errors = errored_distributions.values_list('error_msg', flat=True)
+        return "\n".join(errors)

--- a/series_tiempo_ar_api/libs/indexing/tests/report_tests.py
+++ b/series_tiempo_ar_api/libs/indexing/tests/report_tests.py
@@ -100,3 +100,24 @@ class ReportMailSenderTests(TestCase):
         ReportGenerator(self.task).generate()
         log_body = mail.outbox[0].attachments[-1][1]
         self.assertIn(error_id, log_body)
+
+    def test_error_logs_for_single_node(self):
+        parse_catalog('test_catalog', os.path.join(SAMPLES_DIR, 'one_distribution_ok_one_error.json'))
+        Node.objects.get(catalog_id='test_catalog').admins.add(User.objects.first())
+        parse_catalog('other_catalog', os.path.join(SAMPLES_DIR, 'broken_catalog.json'))
+        ReportGenerator(self.task).generate()
+        error_id = Distribution.objects.filter(dataset__catalog__identifier='test_catalog',
+                                               error=True).first().identifier
+        log_body = mail.outbox[1].attachments[-1][1]
+        self.assertIn(error_id, log_body)
+
+    def test_error_logs_for_single_node_does_not_have_other_catalog_errors(self):
+        parse_catalog('test_catalog', os.path.join(SAMPLES_DIR, 'one_distribution_ok_one_error.json'))
+        Node.objects.get(catalog_id='test_catalog').admins.add(User.objects.first())
+        parse_catalog('other_catalog', os.path.join(SAMPLES_DIR, 'broken_catalog.json'))
+        ReportGenerator(self.task).generate()
+        other_id = Distribution.objects.filter(
+            dataset__catalog__identifier='other_catalog',
+            error=True).first().identifier
+        log_body = mail.outbox[1].attachments[-1][1]
+        self.assertNotIn(other_id, log_body)


### PR DESCRIPTION
Closes #532 

En vez de pasar self.task.logs (que ni siquiera tenía garantía de contener los errores de las distribuciones), ahora se leen individualmente por cada distribución, y si el reporte es para un nodo individual, se filtran los errores que no sean de ese nodo.