### PR TITLE
Bugfix de representation_mode_units + refactor

### DIFF
--- a/scripts/pycodestyle.sh
+++ b/scripts/pycodestyle.sh
@@ -6,6 +6,6 @@ cd ${DIR}/..
 
 
 echo "Running pycodestyle"
-pycodestyle series_tiempo_ar_api -v
+pycodestyle series_tiempo_ar_api
 
 echo "pycodestyle OK :)"

--- a/series_tiempo_ar_api/apps/api/query/constants.py
+++ b/series_tiempo_ar_api/apps/api/query/constants.py
@@ -141,6 +141,8 @@ IN_MEMORY_AGGS = [
 
 PARAM_LAST = 'last'
 
+PERCENT_REP_MODES = (PCT_CHANGE, PCT_CHANGE_YEAR_AGO)
+
 VERBOSE_REP_MODES = {
     VALUE: None,
     CHANGE: "Variación respecto del período anterior",

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -4,13 +4,11 @@ from collections import OrderedDict
 from typing import Union
 
 from django.conf import settings
-from iso8601 import iso8601
 from django_datajsonar.models import Catalog, Dataset, Distribution, Field
 
 from series_tiempo_ar_api.apps.api.exceptions import CollapseError
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
 from series_tiempo_ar_api.apps.api.query import constants
-from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.api.query.series_query import SeriesQuery
 from series_tiempo_ar_api.apps.management import meta_keys
 from .es_query.es_query import ESQuery

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -53,13 +53,16 @@ class Query:
     def add_series(self, name, field_model,
                    rep_mode=constants.API_DEFAULT_VALUES[constants.PARAM_REP_MODE],
                    collapse_agg=constants.API_DEFAULT_VALUES[constants.PARAM_COLLAPSE_AGG]):
-        self.series.append(SeriesQuery(field_model, rep_mode))
+        serie_query = SeriesQuery(field_model, rep_mode)
+        self.series.append(serie_query)
+
         periodicities = self._series_periodicities()
         max_periodicity = self.get_max_periodicity(periodicities)
         self.update_collapse(collapse=max_periodicity)
+
         # Fix a casos en donde collapse agg no es avg pero los valores serían iguales a avg
         # Estos valores no son indexados! Entonces seteamos la aggregation a avg manualmente
-        if max_periodicity == self.series[-1].periodicity():
+        if max_periodicity == serie_query.periodicity():
             collapse_agg = constants.AGG_DEFAULT
 
         self.es_query.add_series(name, rep_mode, max_periodicity, collapse_agg)

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -50,7 +50,7 @@ class Query:
             return [serie.title() for serie in self.series]
 
         if how == constants.HEADER_PARAM_DESCRIPTIONS:
-            return [serie.description() for serie  in self.series]
+            return [serie.description() for serie in self.series]
 
         return self.es_query.get_series_ids()
 

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -47,10 +47,10 @@ class Query:
             raise ValueError
 
         if how == constants.HEADER_PARAM_NAMES:
-            return [model.title for model in self.series_models]
+            return [serie.title() for serie in self.series]
 
         if how == constants.HEADER_PARAM_DESCRIPTIONS:
-            return [json.loads(model.metadata).get('description', '') for model in self.series_models]
+            return [serie.description() for serie  in self.series]
 
         return self.es_query.get_series_ids()
 

--- a/series_tiempo_ar_api/apps/api/query/query.py
+++ b/series_tiempo_ar_api/apps/api/query/query.py
@@ -184,14 +184,7 @@ class Query:
         y field de cada una de las series cargadas en la query
         """
 
-        result = []
-        for field in self.series_models:
-            result.append({
-                'id': field.identifier,
-                'distribution': field.distribution.identifier,
-                'dataset': field.distribution.dataset.identifier
-            })
-        return result
+        return [serie.get_identifiers() for serie in self.series]
 
     def flatten_metadata_response(self):
         self.metadata_flatten = True

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -16,3 +16,10 @@ class SeriesQuery:
 
     def get_metadata(self, flat=False, simple=True):
         return MetadataResponse(self.field_model, flat=flat, simple=simple).get_response()
+
+    def get_identifiers(self):
+        return {
+            'id': self.field_model.identifier,
+            'distribution': self.field_model.distribution.identifier,
+            'dataset': self.field_model.distribution.dataset.identifier
+        }

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -3,15 +3,18 @@ import json
 from iso8601 import iso8601
 
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
+from series_tiempo_ar_api.apps.api.query import constants
 from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.management import meta_keys
 
 
 class SeriesQuery:
+    """Encapsula metadatos de la consulta de una serie con un modo de representación determinado"""
 
     def __init__(self, field_model, rep_mode):
         self.field_model = field_model
         self.rep_mode = rep_mode
+        self.metadata = json.loads(self.field_model.metadata)
 
     def periodicity(self):
         serie_periodicity = meta_keys.get(self.field_model, meta_keys.PERIODICITY)
@@ -19,7 +22,27 @@ class SeriesQuery:
         return get_periodicity_human_format(serie_periodicity or distribution_periodicity)
 
     def get_metadata(self, flat=False, simple=True):
-        return MetadataResponse(self.field_model, flat=flat, simple=simple).get_response()
+        response = MetadataResponse(self.field_model, flat=flat, simple=simple).get_response()
+
+        self._add_is_percentage(response, flat)
+        self._add_rep_mode(response, flat)
+        return response
+
+    def _add_is_percentage(self, response, flat):
+        is_percentage = self.rep_mode in constants.PERCENT_REP_MODES
+        if not flat:
+            response['field']['is_percentage'] = is_percentage
+        else:
+            response['field_is_percentage'] = is_percentage
+
+    def _add_rep_mode(self, response, flat):
+        units = constants.VERBOSE_REP_MODES[self.rep_mode] or self.metadata.get('units')
+        if not flat:
+            response['field']['representation_mode'] = self.rep_mode
+            response['field']['representation_mode_units'] = units
+        else:
+            response['field_representation_mode'] = self.rep_mode
+            response['field_representation_mode_units'] = units
 
     def get_identifiers(self):
         return {
@@ -32,7 +55,7 @@ class SeriesQuery:
         return self.field_model.title
 
     def description(self):
-        return json.loads(self.field_model.metadata).get('description', '')
+        return self.metadata.get('description', '')
 
     def start_date(self):
         date_string = meta_keys.get(self.field_model, meta_keys.INDEX_START)

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -1,0 +1,14 @@
+from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
+from series_tiempo_ar_api.apps.management import meta_keys
+
+
+class SeriesQuery:
+
+    def __init__(self, field_model, rep_mode):
+        self.field_model = field_model
+        self.rep_mode = rep_mode
+
+    def periodicity(self):
+        serie_periodicity = meta_keys.get(self.field_model, meta_keys.PERIODICITY)
+        distribution_periodicity = meta_keys.get(self.field_model.distribution, meta_keys.PERIODICITY)
+        return get_periodicity_human_format(serie_periodicity or distribution_periodicity)

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -1,4 +1,5 @@
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
+from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.management import meta_keys
 
 
@@ -12,3 +13,6 @@ class SeriesQuery:
         serie_periodicity = meta_keys.get(self.field_model, meta_keys.PERIODICITY)
         distribution_periodicity = meta_keys.get(self.field_model.distribution, meta_keys.PERIODICITY)
         return get_periodicity_human_format(serie_periodicity or distribution_periodicity)
+
+    def get_metadata(self, flat=False, simple=True):
+        return MetadataResponse(self.field_model, flat=flat, simple=simple).get_response()

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -1,3 +1,5 @@
+import json
+
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
 from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.management import meta_keys
@@ -23,3 +25,9 @@ class SeriesQuery:
             'distribution': self.field_model.distribution.identifier,
             'dataset': self.field_model.distribution.dataset.identifier
         }
+
+    def title(self):
+        return self.field_model.title
+
+    def description(self):
+        return json.loads(self.field_model.metadata).get('description', '')

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -1,5 +1,7 @@
 import json
 
+from iso8601 import iso8601
+
 from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
 from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.management import meta_keys
@@ -31,3 +33,9 @@ class SeriesQuery:
 
     def description(self):
         return json.loads(self.field_model.metadata).get('description', '')
+
+    def start_date(self):
+        date_string = meta_keys.get(self.field_model, meta_keys.INDEX_START)
+        if date_string is None:
+            return None
+        return iso8601.parse_date(date_string).date()

--- a/series_tiempo_ar_api/apps/api/tests/query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/query_tests.py
@@ -91,11 +91,6 @@ class QueryTests(TestCase):
         delta = second_date - first_date
         self.assertEqual(delta.days, 7)
 
-    def add_series_with_aggregation(self):
-        # Aggregation sin haber definido collapse NO HACE NADA!
-        self.query.add_series(self.single_series, self.field, collapse_agg='sum')
-        self.assertTrue(self.query.series_models)
-
     def test_simple_metadata_remove_catalog(self):
         catalog = self.field.distribution.dataset.catalog
         catalog.metadata = '{"title": "test_title", "extra_field": "extra"}'
@@ -281,3 +276,13 @@ class QueryTests(TestCase):
 
         for row in data:
             self.assertEqual(row[1], row[2])
+
+    def test_same_series_multiple_times_different_rep_mode(self):
+        month_series = get_series_id('month')
+        self.query.add_series(month_series, self.field)
+        self.query.add_series(month_series, self.field, rep_mode='percent_change')
+        self.query.set_metadata_config(how=constants.METADATA_ONLY)
+        meta = self.query.run()['meta']
+
+        self.assertEqual(meta[1]['field']['representation_mode'], 'value')
+        self.assertEqual(meta[2]['field']['representation_mode'], 'percent_change')

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 
 from django.test import TestCase
 
@@ -63,3 +64,10 @@ class SeriesQueryTests(TestCase):
         self.field.metadata = json.dumps({})
         description = self.serie.description()
         self.assertEqual(description, '')
+
+    def test_get_start_date(self):
+        self.assertEqual(self.serie.start_date(), datetime(1910, 1, 1).date())
+
+    def test_get_start_date_none_if_not_set(self):
+        self.field.enhanced_meta.all().delete()
+        self.assertEqual(self.serie.start_date(), None)

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+
+from django_datajsonar.models import Field
+from series_tiempo_ar_api.apps.api.query import constants
+from series_tiempo_ar_api.apps.api.query.series_query import SeriesQuery
+from series_tiempo_ar_api.apps.api.tests.helpers import get_series_id
+
+
+class SeriesQueryTests(TestCase):
+    single_series = get_series_id('month')
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.field = Field.objects.get(identifier=cls.single_series)
+
+    def test_get_periodicity(self):
+        periodicity = SeriesQuery(self.field, constants.VALUE).periodicity()
+        self.assertEqual(periodicity, 'month')

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -15,9 +15,10 @@ class SeriesQueryTests(TestCase):
         self.field = Field.objects.get(identifier=self.single_series)
         self.field_description = "Mi descripción"
         self.field.metadata = json.dumps({'description': self.field_description})
+        self.serie = SeriesQuery(self.field, constants.VALUE)
 
     def test_get_periodicity(self):
-        periodicity = SeriesQuery(self.field, constants.VALUE).periodicity()
+        periodicity = self.serie.periodicity()
         self.assertEqual(periodicity, 'month')
 
     def test_get_periodicity_reads_from_distribution_if_serie_has_none(self):
@@ -26,7 +27,7 @@ class SeriesQueryTests(TestCase):
         self.assertEqual(periodicity, 'month')
 
     def test_get_metadata_has_values_for_all_levels(self):
-        meta = SeriesQuery(self.field, constants.VALUE).get_metadata()
+        meta = self.serie.get_metadata()
 
         self.assertIn('catalog', meta)
         self.assertIn('dataset', meta)
@@ -34,32 +35,31 @@ class SeriesQueryTests(TestCase):
         self.assertIn('field', meta)
 
     def test_get_metadata_flatten_has_description_in_first_level(self):
-        meta = SeriesQuery(self.field, constants.VALUE).get_metadata(flat=True)
+        meta = self.serie.get_metadata(flat=True)
         self.assertIn('field_description', meta)
         self.assertNotIn('field', meta)
 
     def test_enhanced_meta_not_in_metadata_if_query_is_simple(self):
-        meta = SeriesQuery(self.field, constants.VALUE).get_metadata(simple=True)
+        meta = self.serie.get_metadata(simple=True)
 
         self.assertNotIn('available', meta['field'])
 
     def test_get_identifiers(self):
-        serie = SeriesQuery(self.field, constants.VALUE)
-        ids = serie.get_identifiers()
+        ids = self.serie.get_identifiers()
 
         self.assertEqual(ids['id'], self.field.identifier)
         self.assertEqual(ids['distribution'], self.field.distribution.identifier)
         self.assertEqual(ids['dataset'], self.field.distribution.dataset.identifier)
 
     def test_get_title(self):
-        title = SeriesQuery(self.field, constants.VALUE).title()
+        title = self.serie.title()
         self.assertEqual(title, self.field.title)
 
     def test_get_description(self):
-        description = SeriesQuery(self.field, constants.VALUE).description()
+        description = self.serie.description()
         self.assertEqual(description, self.field_description)
 
     def test_get_description_no_description_set(self):
         self.field.metadata = json.dumps({})
-        description = SeriesQuery(self.field, constants.VALUE).description()
+        description = self.serie.description()
         self.assertEqual(description, '')

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -15,7 +15,8 @@ class SeriesQueryTests(TestCase):
     def setUp(self):
         self.field = Field.objects.get(identifier=self.single_series)
         self.field_description = "Mi descripción"
-        self.field.metadata = json.dumps({'description': self.field_description})
+        self.field.metadata = json.dumps({'description': self.field_description,
+                                          'units': 'my_units'})
         self.serie = SeriesQuery(self.field, constants.VALUE)
 
     def test_get_periodicity(self):
@@ -62,7 +63,7 @@ class SeriesQueryTests(TestCase):
 
     def test_get_description_no_description_set(self):
         self.field.metadata = json.dumps({})
-        description = self.serie.description()
+        description = SeriesQuery(self.field, constants.VALUE).description()
         self.assertEqual(description, '')
 
     def test_get_start_date(self):
@@ -71,3 +72,45 @@ class SeriesQueryTests(TestCase):
     def test_get_start_date_none_if_not_set(self):
         self.field.enhanced_meta.all().delete()
         self.assertEqual(self.serie.start_date(), None)
+
+    def test_metadata_is_percentage_default_rep_mode(self):
+        meta = self.serie.get_metadata()
+        self.assertFalse(meta['field']['is_percentage'])
+
+    def test_metadata_is_percentage_with_percentage_rep_mode(self):
+        meta = SeriesQuery(self.field, constants.PCT_CHANGE).get_metadata()
+        self.assertTrue(meta['field']['is_percentage'])
+
+    def test_metadata_is_percentage_with_flat_metadata(self):
+        meta = SeriesQuery(self.field, constants.PCT_CHANGE).get_metadata(flat=True)
+        self.assertTrue(meta['field_is_percentage'])
+
+    def test_metadata_is_not_percentage_with_flat_metadata(self):
+        meta = self.serie.get_metadata(flat=True)
+        self.assertFalse(meta['field_is_percentage'])
+
+    def test_metadata_rep_mode(self):
+        rep_mode = self.serie.get_metadata()['field']['representation_mode']
+        self.assertEqual(rep_mode, constants.VALUE)
+
+    def test_metadata_rep_mode_flat(self):
+        meta = self.serie.get_metadata(flat=True)
+        self.assertEqual(meta['field_representation_mode'], constants.VALUE)
+
+    def test_metadata_rep_mode_units_copy_of_units_if_value(self):
+        meta = self.serie.get_metadata()
+        self.assertEqual(meta['field']['units'], meta['field']['representation_mode_units'])
+
+    def test_metadata_rep_mode_units_copy_of_units_if_value_flat(self):
+        meta = self.serie.get_metadata(flat=True)
+        self.assertEqual(meta['field_units'], meta['field_representation_mode_units'])
+
+    def test_metadata_rep_mode_units_none_if_no_units_set(self):
+        self.field.metadata = json.dumps({})
+        meta = SeriesQuery(self.field, constants.VALUE).get_metadata()
+        self.assertIsNone(meta['field']['representation_mode_units'])
+
+    def test_metadata_rep_mode_units_for_percentage_rep_mode(self):
+        meta = SeriesQuery(self.field, constants.PCT_CHANGE).get_metadata()
+        self.assertEqual(constants.VERBOSE_REP_MODES[constants.PCT_CHANGE],
+                         meta['field']['representation_mode_units'])

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -1,3 +1,5 @@
+import json
+
 from django.test import TestCase
 
 from django_datajsonar.models import Field
@@ -9,9 +11,10 @@ from series_tiempo_ar_api.apps.api.tests.helpers import get_series_id
 class SeriesQueryTests(TestCase):
     single_series = get_series_id('month')
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.field = Field.objects.get(identifier=cls.single_series)
+    def setUp(self):
+        self.field = Field.objects.get(identifier=self.single_series)
+        self.field_description = "Mi descripción"
+        self.field.metadata = json.dumps({'description': self.field_description})
 
     def test_get_periodicity(self):
         periodicity = SeriesQuery(self.field, constants.VALUE).periodicity()
@@ -47,3 +50,16 @@ class SeriesQueryTests(TestCase):
         self.assertEqual(ids['id'], self.field.identifier)
         self.assertEqual(ids['distribution'], self.field.distribution.identifier)
         self.assertEqual(ids['dataset'], self.field.distribution.dataset.identifier)
+
+    def test_get_title(self):
+        title = SeriesQuery(self.field, constants.VALUE).title()
+        self.assertEqual(title, self.field.title)
+
+    def test_get_description(self):
+        description = SeriesQuery(self.field, constants.VALUE).description()
+        self.assertEqual(description, self.field_description)
+
+    def test_get_description_no_description_set(self):
+        self.field.metadata = json.dumps({})
+        description = SeriesQuery(self.field, constants.VALUE).description()
+        self.assertEqual(description, '')

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -16,3 +16,26 @@ class SeriesQueryTests(TestCase):
     def test_get_periodicity(self):
         periodicity = SeriesQuery(self.field, constants.VALUE).periodicity()
         self.assertEqual(periodicity, 'month')
+
+    def test_get_periodicity_reads_from_distribution_if_serie_has_none(self):
+        self.field.enhanced_meta.all().delete()
+        periodicity = SeriesQuery(self.field, constants.VALUE).periodicity()
+        self.assertEqual(periodicity, 'month')
+
+    def test_get_metadata_has_values_for_all_levels(self):
+        meta = SeriesQuery(self.field, constants.VALUE).get_metadata()
+
+        self.assertIn('catalog', meta)
+        self.assertIn('dataset', meta)
+        self.assertIn('distribution', meta)
+        self.assertIn('field', meta)
+
+    def test_get_metadata_flatten_has_description_in_first_level(self):
+        meta = SeriesQuery(self.field, constants.VALUE).get_metadata(flat=True)
+        self.assertIn('field_description', meta)
+        self.assertNotIn('field', meta)
+
+    def test_enhanced_meta_not_in_metadata_if_query_is_simple(self):
+        meta = SeriesQuery(self.field, constants.VALUE).get_metadata(simple=True)
+
+        self.assertNotIn('available', meta['field'])

--- a/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/series_query_tests.py
@@ -39,3 +39,11 @@ class SeriesQueryTests(TestCase):
         meta = SeriesQuery(self.field, constants.VALUE).get_metadata(simple=True)
 
         self.assertNotIn('available', meta['field'])
+
+    def test_get_identifiers(self):
+        serie = SeriesQuery(self.field, constants.VALUE)
+        ids = serie.get_identifiers()
+
+        self.assertEqual(ids['id'], self.field.identifier)
+        self.assertEqual(ids['distribution'], self.field.distribution.identifier)
+        self.assertEqual(ids['dataset'], self.field.distribution.dataset.identifier)


### PR DESCRIPTION
- Saca toda la lógica de armado de metadatos en `Query` en un objeto aparte, `SeriesQuery`, que lo arma por cada serie.

- Corrijo el bug de que si se agregaba dos series de mismo id pero con diferente rep mode, (ejemplo: http://localhost:8000/api/series/?ids=116.4_TCRZE_2015_D_26_49,116.4_TCRZE_2015_D_26_49:percent_change), el campo `representation_mode_units` decía `value` en ambos, cuando debía decir `value` para el primero y `percent_change` para el segundo

Closes #589 