### PR TITLE
is_percentage fix

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/metadata_response.py
+++ b/series_tiempo_ar_api/apps/api/query/metadata_response.py
@@ -42,27 +42,8 @@ class MetadataResponse:
             'catalog': self._get_full_metadata_for_model(catalog),
             'dataset': dataset_meta,
             'distribution': self._get_full_metadata_for_model(distribution),
-            'field': self._field_metadata(self.field),
+            'field': self._get_full_metadata_for_model(self.field),
         }
-
-    def _field_metadata(self, field: Field):
-        metadata = self._get_full_metadata_for_model(field)
-        if self.simple:
-            return metadata
-
-        metadata.update({'is_percentage': False})
-        units = metadata.get('units')
-
-        if not units:
-            return metadata
-
-        try:
-            series_units = SeriesUnits.objects.get(name=units)
-        except SeriesUnits.DoesNotExist:
-            return metadata
-
-        metadata['is_percentage'] = series_units.percentage
-        return metadata
 
     def _get_full_metadata_for_model(self, model: datajson_entity):
         metadata = {}

--- a/series_tiempo_ar_api/apps/api/query/series_query.py
+++ b/series_tiempo_ar_api/apps/api/query/series_query.py
@@ -6,6 +6,7 @@ from series_tiempo_ar_api.apps.api.helpers import get_periodicity_human_format
 from series_tiempo_ar_api.apps.api.query import constants
 from series_tiempo_ar_api.apps.api.query.metadata_response import MetadataResponse
 from series_tiempo_ar_api.apps.management import meta_keys
+from series_tiempo_ar_api.apps.metadata.models import SeriesUnits
 
 
 class SeriesQuery:
@@ -24,12 +25,14 @@ class SeriesQuery:
     def get_metadata(self, flat=False, simple=True):
         response = MetadataResponse(self.field_model, flat=flat, simple=simple).get_response()
 
-        self._add_is_percentage(response, flat)
+        if not simple:
+            self._add_is_percentage(response, flat)
         self._add_rep_mode(response, flat)
         return response
 
     def _add_is_percentage(self, response, flat):
-        is_percentage = self.rep_mode in constants.PERCENT_REP_MODES
+        units_is_percentage = SeriesUnits.is_percentage(self.metadata.get('units'))
+        is_percentage = self.rep_mode in constants.PERCENT_REP_MODES or units_is_percentage
         if not flat:
             response['field']['is_percentage'] = is_percentage
         else:

--- a/series_tiempo_ar_api/apps/api/tests/helpers.py
+++ b/series_tiempo_ar_api/apps/api/tests/helpers.py
@@ -63,7 +63,7 @@ def init_month_series(dataset):
     distrib.enhanced_meta.create(key=meta_keys.PERIODICITY, value='R/P1M')
     field = Field.objects.create(
         identifier=settings.TEST_SERIES_NAME.format('month'),
-        metadata='{"description": "test_series_description"}',
+        metadata='{"description": "test_series_description", "units": "percentage"}',
         distribution=distrib,
         title='random_month_0_title'
     )

--- a/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/metadata_tests.py
@@ -33,29 +33,3 @@ class MetadataResponseTests(TestCase):
 
         self.assertTrue(isinstance(full_meta['dataset']['theme'], list))
         self.assertEqual(full_meta['dataset']['theme'][0]['label'], 'test_label')
-
-    def test_percentage_metadata_not_available_if_simple(self):
-        simple_meta = MetadataResponse(self.field, simple=True, flat=False).get_response()
-        self.assertNotIn('is_percentage', simple_meta['field'])
-
-    def test_percentage_metadata_is_false_if_no_series_units_model(self):
-        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
-        self.assertFalse(meta['field']['is_percentage'])
-
-    def test_percentage_metadata_false_if_no_units_field(self):
-        self.field.metadata = '{}'
-        self.field.save()
-        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
-        self.assertFalse(meta['field']['is_percentage'])
-
-    def test_percentage_metadata_false_if_units_arent_percentage(self):
-        SeriesUnits.objects.create(name=self.units, percentage=False)
-
-        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
-        self.assertFalse(meta['field']['is_percentage'])
-
-    def test_percent_metadata_true_if_units_are_percentage(self):
-        SeriesUnits.objects.create(name=self.units, percentage=True)
-
-        meta = MetadataResponse(self.field, simple=False, flat=False).get_response()
-        self.assertTrue(meta['field']['is_percentage'])

--- a/series_tiempo_ar_api/apps/metadata/models.py
+++ b/series_tiempo_ar_api/apps/metadata/models.py
@@ -1,5 +1,4 @@
 #! coding: utf-8
-import datetime
 from typing import Sequence
 
 from django.conf import settings
@@ -68,3 +67,10 @@ class SeriesUnits(models.Model):
 
     name = models.CharField(max_length=64, unique=True)
     percentage = models.BooleanField(default=False)
+
+    @classmethod
+    def is_percentage(cls, name):
+        try:
+            return cls.objects.get(name=name).percentage
+        except cls.DoesNotExist:
+            return False

--- a/series_tiempo_ar_api/apps/metadata/tests/series_units_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/series_units_tests.py
@@ -1,0 +1,21 @@
+from django.test import TestCase
+
+from series_tiempo_ar_api.apps.metadata.models import SeriesUnits
+
+
+class SeriesUnitsTests(TestCase):
+
+    def test_is_percentage_no_units(self):
+        self.assertFalse(SeriesUnits.is_percentage('non_existent_units'))
+
+    def test_is_percentage_units_exists_and_tagged_as_percentage(self):
+        SeriesUnits.objects.create(name='pct_units', percentage=True)
+        self.assertTrue(SeriesUnits.is_percentage('pct_units'))
+
+    def test_is_percentage_units_exists_and_not_tagged_as_not_percentage(self):
+        SeriesUnits.objects.create(name='non_pct_units', percentage=False)
+        self.assertFalse(SeriesUnits.is_percentage('non_pct_units'))
+
+    def test_default_is_not_percentage(self):
+        SeriesUnits.objects.create(name='non_pct_units')
+        self.assertFalse(SeriesUnits.is_percentage('non_pct_units'))

--- a/series_tiempo_ar_api/apps/metadata/tests/update_units_tests.py
+++ b/series_tiempo_ar_api/apps/metadata/tests/update_units_tests.py
@@ -7,7 +7,7 @@ from series_tiempo_ar_api.apps.metadata.indexer.units import update_units
 from series_tiempo_ar_api.apps.metadata.models import SeriesUnits
 
 
-class SeriesUnitsTests(TestCase):
+class UpdateUnitsTests(TestCase):
     faker = Faker()
 
     def setUp(self):


### PR DESCRIPTION
Closes #593 

Problema: La lógica `is_percentage` se hacía en dos módulos distintos, primero en `MetadataResponse` y luego en `SeriesQuery`. Este último pisaba el resultado del primero, haciendo que a veces se muestre `false` cuando debería ser `true`. Adicionalmente, `SeriesQuery` siempre mostraba el resultado de `is_percentage`, cuando en realidad solo debería aparecer ese campo si se pide metadatos "completos" (`simple=False`)

Solución: Merge de lógica todo en `SeriesQuery`. Agrego varios casos de prueba, unitarios y de integración. 