### PR TITLE
Reemplazo newlines por breaks en reporte HTML

### DIFF
--- a/templates/indexing/report.html
+++ b/templates/indexing/report.html
@@ -45,7 +45,7 @@ Queries del día anterior: {{ queries }}
     <tr>
         <td>{{ distribution.dataset.catalog.identifier}}</td>
         <td>{{ distribution.identifier }}</td>
-        <td>{{ distribution.error_msg }}</td>
+        <td>{{ distribution.error_msg|linebreaks }}</td>
     </tr>
     {% endfor %}
 </table>


### PR DESCRIPTION
Closes #588 

Queda así
![image](https://user-images.githubusercontent.com/19612265/63430720-a7ba8980-c3f3-11e9-840d-2140f8c2d275.png)