### PR TITLE
Fix a aggs max/min

### DIFF
--- a/series_tiempo_ar_api/apps/api/query/es_query/series.py
+++ b/series_tiempo_ar_api/apps/api/query/es_query/series.py
@@ -91,6 +91,7 @@ class Serie:
             self._search = self._search.filter('bool', must=[Q('match', interval=self.periodicity)])
 
         elif self._has_collapse():
+            self._search = self._search.filter('bool', must=[Q('match', interval=self.original_periodicity)])
             # Agregamos la aggregation (?) para que se ejecute en ES en runtime
             self._search.aggs.bucket('test',
                                      A('date_histogram',

--- a/series_tiempo_ar_api/apps/api/tests/endpoint_tests/aggregations_tests.py
+++ b/series_tiempo_ar_api/apps/api/tests/endpoint_tests/aggregations_tests.py
@@ -1,0 +1,28 @@
+from series_tiempo_ar_api.apps.api.tests.endpoint_tests.endpoint_test_case import EndpointTestCase
+
+
+class AggregationsTests(EndpointTestCase):
+
+    def test_max_aggregation(self):
+        max_value = 130
+
+        data = {'ids': self.increasing_day_series_id,
+                'limit': '1',
+                'collapse': 'month',
+                'collapse_aggregation': 'max'}
+
+        resp = self.run_query(data)
+        aggregated_max = resp['data'][0][1]
+        self.assertEqual(max_value, aggregated_max)
+
+    def test_min_aggregation(self):
+        min_value = 100
+
+        data = {'ids': self.increasing_day_series_id,
+                'limit': '1',
+                'collapse': 'month',
+                'collapse_aggregation': 'min'}
+
+        resp = self.run_query(data)
+        aggregated_min = resp['data'][0][1]
+        self.assertEqual(min_value, aggregated_min)


### PR DESCRIPTION
La agregación de ES se realizaba sobre todos los valores indexados de las series,
incluso los valores de collapse precalculados. Se agrega un filtro adicional
según el período de la serie original para no considerar estos valores sobre
la agregación

Closes #653 
