### PR TITLE
Manejo casos de get time index cuando la distribución no esté presente

### DIFF
--- a/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
+++ b/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
@@ -16,7 +16,7 @@ class DistributionRepository:
         self.csv_reader = csv_reader
 
     def get_time_index_series(self):
-        fields = self.instance.field_set.filter(present=True)
+        fields = self.instance.field_set.filter(present=self.instance.present).reverse()
         for field in fields:
             meta = json.loads(field.metadata)
             if meta.get(constants.SPECIAL_TYPE) == constants.TIME_INDEX:

--- a/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
+++ b/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
@@ -16,7 +16,7 @@ class DistributionRepository:
         self.csv_reader = csv_reader
 
     def get_time_index_series(self):
-        fields = self.instance.field_set.all()
+        fields = self.instance.field_set.filter(present=True)
         for field in fields:
             meta = json.loads(field.metadata)
             if meta.get(constants.SPECIAL_TYPE) == constants.TIME_INDEX:

--- a/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
+++ b/series_tiempo_ar_api/libs/datajsonar_repositories/distribution_repository.py
@@ -16,7 +16,7 @@ class DistributionRepository:
         self.csv_reader = csv_reader
 
     def get_time_index_series(self):
-        fields = self.instance.field_set.filter(present=self.instance.present).reverse()
+        fields = self.instance.field_set.filter(present=self.instance.present).order_by('-id')
         for field in fields:
             meta = json.loads(field.metadata)
             if meta.get(constants.SPECIAL_TYPE) == constants.TIME_INDEX:

--- a/series_tiempo_ar_api/libs/datajsonar_repositories/tests/distribution_repository_tests.py
+++ b/series_tiempo_ar_api/libs/datajsonar_repositories/tests/distribution_repository_tests.py
@@ -75,8 +75,9 @@ class DistributionRepositoryTests(TestCase):
 
     def test_multiple_indices_returns_last_if_distribution_is_not_present(self):
         self.distribution.field_set \
-            .create(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}), present=False)
+            .create(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}), present=False, title='serie_nopresent_1')
         last = self.distribution.field_set \
-            .create(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}), present=False)
+            .create(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}), present=False, title='serie_nopresent_2')
+
         self.distribution.present = False
         self.assertEqual(DistributionRepository(self.distribution).get_time_index_series(), last)

--- a/series_tiempo_ar_api/libs/datajsonar_repositories/tests/distribution_repository_tests.py
+++ b/series_tiempo_ar_api/libs/datajsonar_repositories/tests/distribution_repository_tests.py
@@ -1,11 +1,10 @@
 import json
 import os
 
-from mock import Mock, patch
 from django.core.exceptions import ObjectDoesNotExist
 from django.test import TestCase
 from nose.tools import raises
-from django_datajsonar.models import Node, Distribution
+from django_datajsonar.models import Node, Distribution, Catalog
 
 from series_tiempo_ar_api.libs.datajsonar_repositories.distribution_repository import DistributionRepository
 from series_tiempo_ar_api.libs.indexing import constants
@@ -16,49 +15,37 @@ SAMPLES_DIR = os.path.join(os.path.dirname(__file__), 'samples')
 
 class DistributionRepositoryTests(TestCase):
 
-    def test_get_time_index(self):
-        time_index_field = Mock(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}))
-        distribution = Mock()
-        distribution.field_set.all.return_value = [time_index_field]
+    @classmethod
+    def setUpTestData(cls):
+        url = 'http://localhost:3456/series_tiempo_ar_api/libs/datajsonar_repositories/tests/samples/test_catalog.json'
+        cls.node = Node.objects.create(catalog_id='repo_test_catalog', indexable=True,
+                                       catalog_url=url)
+        catalog = Catalog.objects.create(metadata='{}', identifier=cls.node.catalog_id)
+        dataset = catalog.dataset_set.create(metadata='{}')
+        cls.distribution = dataset.distribution_set.create(metadata='{}', identifier='1')
 
-        self.assertEqual(DistributionRepository(distribution).get_time_index_series(), time_index_field)
+    def test_get_time_index(self):
+        time_index_field = self.distribution.field_set\
+            .create(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}))
+
+        self.assertEqual(DistributionRepository(self.distribution).get_time_index_series(), time_index_field)
 
     @raises(ObjectDoesNotExist)
     def test_get_time_index_none_exists(self):
-        distribution = Mock()
-        distribution.field_set.all.return_value = []
-        DistributionRepository(distribution).get_time_index_series()
+        DistributionRepository(self.distribution).get_time_index_series()
 
     def test_get_node(self):
-        distribution = Mock()
-        distribution.dataset.catalog.identifier = 'test_node'
+        self.assertEqual(DistributionRepository(self.distribution).get_node(), self.node)
 
-        node = Node(catalog_id='test_node')
-        with patch('series_tiempo_ar_api.libs.datajsonar_repositories.distribution_repository.Node') as fake_node:
-            fake_node.objects.get.return_value = node
-            self.assertTrue(fake_node.objects.get.called_with(catalog_id='test_node'))
-            self.assertEqual(DistributionRepository(distribution).get_node(), node)
-
-    @patch('series_tiempo_ar_api.libs.datajsonar_repositories.distribution_repository.Node')
-    @patch('series_tiempo_ar_api.libs.datajsonar_repositories.node_repository.NodeRepository')
-    def test_get_data_json(self, repository, fake_node):
-        distribution = Mock()
-        node = Node(catalog_id='test_node')
-        fake_node.objects.get.return_value = node
-        DistributionRepository(distribution).get_data_json()
-        self.assertTrue(repository.called_with(node))
+    def test_get_data_json(self):
+        data_json = DistributionRepository(self.distribution).get_data_json()
+        self.assertTrue(data_json.get_distributions())
 
     def test_read_csv_as_dataframe(self):
-        time_index_title = 'indice_tiempo'
-        time_index_field = Mock(metadata=json.dumps({constants.SPECIAL_TYPE: constants.TIME_INDEX}),
-                                title=time_index_title)
-
-        distribution = Mock()
-        distribution.field_set.all.return_value = [time_index_field]
-
-        csv_reader = Mock()
-        DistributionRepository(distribution, csv_reader=csv_reader).read_csv_as_time_series_dataframe()
-        csv_reader.assert_called_with(distribution, time_index_title)
+        parse_catalog('test_catalog', os.path.join(SAMPLES_DIR, 'test_catalog.json'))
+        distribution = Distribution.objects.last()
+        df = DistributionRepository(distribution).read_csv_as_time_series_dataframe()
+        self.assertTrue(list(df.columns))
 
     def test_get_errored_distributions_is_empty_if_all_ok(self):
         parse_catalog('test_catalog', os.path.join(SAMPLES_DIR, 'test_catalog.json'))


### PR DESCRIPTION
Closes #658 

Solución permanente al caso 'se cambió el ID del índice de tiempo y ahora existen múltiples series taggeadas como time_index, con una sola con present=True'

También saqué todos los mocks de los test cases, pasando a testear de una manera más de integración